### PR TITLE
達成基準 1.4.12 テキストの間隔 : 「注記」の翻訳

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -995,7 +995,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 
  <div class="note" role="note" id="issue-container-generatedID-10"><div role="heading" class="note-title marker" id="h-note-10" aria-level="5"><span>注記 1</span></div><p class="">コンテンツが、これらのテキストの間隔の値を用いる必要はない。要求事項は、制作者が指定したテキストの間隔を利用者が上書きした場合に、コンテンツ又は機能が失われないことである。</p></div>
 
- <div class="note" role="note" id="issue-container-generatedID-11"><div role="heading" class="note-title marker" id="h-note-11" aria-level="5"><span>注記 2</span></div><p class="">一部の言語の書記体系では、例えば段落開始のインデントのように、異なるテキストの間隔の設定が用いられているものもある。コンテンツ制作者は、テキストの可読性及び視認性を向上させるために、地域で入手可能なその書記体系のガイドラインに従うことが推奨される。</p></div>
+ <div class="note" role="note" id="issue-container-generatedID-11"><div role="heading" class="note-title marker" id="h-note-11" aria-level="5"><span>注記 2</span></div><p class="">言語の中には、書記体系において、例えば段落開始のインデントのように、異なるテキストの間隔の設定が用いられるものもある。コンテンツ制作者は、テキストの可読性及び視認性を向上させるために、その書記体系の、その地域に適用されるガイドラインに従うことが推奨される。</p></div>
  
 </section>
 

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -995,7 +995,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 
  <div class="note" role="note" id="issue-container-generatedID-10"><div role="heading" class="note-title marker" id="h-note-10" aria-level="5"><span>注記 1</span></div><p class="">コンテンツが、これらのテキストの間隔の値を用いる必要はない。要求事項は、制作されたテキストの間隔を利用者が上書きした場合に、コンテンツ又は機能が失われないことである。</p></div>
 
- <div class="note" role="note" id="issue-container-generatedID-11"><div role="heading" class="note-title marker" id="h-note-11" aria-level="5"><span>注記 2</span></div><p class="">言語の中には、書記体系において、例えば段落開始のインデントのように、テキストの間隔について異なる設定が用いられているものもある。コンテンツ制作者は、テキストの可読性及び文字の識別性を高めるために、そうした言語の書記体系のローカル指針に従うことが推奨される。</p></div>
+ <div class="note" role="note" id="issue-container-generatedID-11"><div role="heading" class="note-title marker" id="h-note-11" aria-level="5"><span>注記 2</span></div><p class="">言語の中には、書記体系において、例えば段落開始のインデントのように、テキストの間隔について異なる設定が用いられているものもある。コンテンツ制作者は、テキストの可読性及び視認性を向上させるために、言語の書記体系のローカルなガイドラインに従うことが推奨される。</p></div>
  
 </section>
 

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -993,7 +993,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
  
  <p>例外: テキスト表記においてこれらのテキストスタイルプロパティの一つ以上を使用しない自然言語及び文字体系では、その言語と文字体系の組み合わせに存在するプロパティだけを用いて、この達成基準に適合することができる。</p>
 
- <div class="note" role="note" id="issue-container-generatedID-10"><div role="heading" class="note-title marker" id="h-note-10" aria-level="5"><span>注記 1</span></div><p class="">コンテンツが、これらのテキストの間隔の値を用いる必要はない。要求事項は、制作されたテキストの間隔を利用者が上書きした場合に、コンテンツ又は機能が失われないことである。</p></div>
+ <div class="note" role="note" id="issue-container-generatedID-10"><div role="heading" class="note-title marker" id="h-note-10" aria-level="5"><span>注記 1</span></div><p class="">コンテンツが、これらのテキストの間隔の値を用いる必要はない。要求事項は、制作者が指定したテキストの間隔を利用者が上書きした場合に、コンテンツ又は機能が失われないことである。</p></div>
 
  <div class="note" role="note" id="issue-container-generatedID-11"><div role="heading" class="note-title marker" id="h-note-11" aria-level="5"><span>注記 2</span></div><p class="">一部の言語の書記体系では、例えば段落開始のインデントのように、異なるテキストの間隔の設定が用いられているものもある。コンテンツ制作者は、テキストの可読性及び視認性を向上させるために、地域で入手可能なその書記体系のガイドラインに従うことが推奨される。</p></div>
  

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -993,9 +993,9 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
  
  <p>例外: テキスト表記においてこれらのテキストスタイルプロパティの一つ以上を使用しない自然言語及び文字体系では、その言語と文字体系の組み合わせに存在するプロパティだけを用いて、この達成基準に適合することができる。</p>
 
- <div class="note" role="note" id="issue-container-generatedID-10"><div role="heading" class="note-title marker" id="h-note-10" aria-level="5"><span>注記 1</span></div><p class="">コンテンツでは、これらのテキストの間隔の値を用いることは必須ではない。要件はあくまで、制作されたテキストの間隔を利用者が上書きした場合に、コンテンツ又は機能が失われないことである。</p></div>
+ <div class="note" role="note" id="issue-container-generatedID-10"><div role="heading" class="note-title marker" id="h-note-10" aria-level="5"><span>注記 1</span></div><p class="">コンテンツが、これらのテキストの間隔の値を用いる必要はない。要求事項は、制作されたテキストの間隔を利用者が上書きした場合に、コンテンツ又は機能が失われないことである。</p></div>
 
- <div class="note" role="note" id="issue-container-generatedID-11"><div role="heading" class="note-title marker" id="h-note-11" aria-level="5"><span>注記 2</span></div><p class="">一部の言語の記述体系では、例えば段落開始のインデントのように、テキストの間隔について異なる設定が用いられている。コンテンツ制作者は、テキストの可読性及び文字の識別性を高めるために、そうした言語記述体系のローカル指針に従うことが推奨される。</p></div>
+ <div class="note" role="note" id="issue-container-generatedID-11"><div role="heading" class="note-title marker" id="h-note-11" aria-level="5"><span>注記 2</span></div><p class="">言語の中には、書記体系において、例えば段落開始のインデントのように、テキストの間隔について異なる設定が用いられているものもある。コンテンツ制作者は、テキストの可読性及び文字の識別性を高めるために、そうした言語の書記体系のローカル指針に従うことが推奨される。</p></div>
  
 </section>
 

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -995,7 +995,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 
  <div class="note" role="note" id="issue-container-generatedID-10"><div role="heading" class="note-title marker" id="h-note-10" aria-level="5"><span>注記 1</span></div><p class="">コンテンツが、これらのテキストの間隔の値を用いる必要はない。要求事項は、制作されたテキストの間隔を利用者が上書きした場合に、コンテンツ又は機能が失われないことである。</p></div>
 
- <div class="note" role="note" id="issue-container-generatedID-11"><div role="heading" class="note-title marker" id="h-note-11" aria-level="5"><span>注記 2</span></div><p class="">言語の中には、書記体系において、例えば段落開始のインデントのように、テキストの間隔について異なる設定が用いられているものもある。コンテンツ制作者は、テキストの可読性及び視認性を向上させるために、言語の書記体系のローカルなガイドラインに従うことが推奨される。</p></div>
+ <div class="note" role="note" id="issue-container-generatedID-11"><div role="heading" class="note-title marker" id="h-note-11" aria-level="5"><span>注記 2</span></div><p class="">一部の言語の書記体系では、例えば段落開始のインデントのように、異なるテキストの間隔の設定が用いられているものもある。コンテンツ制作者は、テキストの可読性及び視認性を向上させるために、地域で入手可能なその書記体系のガイドラインに従うことが推奨される。</p></div>
  
 </section>
 

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -993,9 +993,9 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
  
  <p>例外: テキスト表記においてこれらのテキストスタイルプロパティの一つ以上を使用しない自然言語及び文字体系では、その言語と文字体系の組み合わせに存在するプロパティだけを用いて、この達成基準に適合することができる。</p>
 
- <div class="note" role="note" id="issue-container-generatedID-10"><div role="heading" class="note-title marker" id="h-note-10" aria-level="5"><span>注記 1</span></div><p class="">Content is not required to use these text spacing values. The requirement is to ensure that when a user overrides the authored text spacing, content or functionality is not lost.</p></div>
+ <div class="note" role="note" id="issue-container-generatedID-10"><div role="heading" class="note-title marker" id="h-note-10" aria-level="5"><span>注記 1</span></div><p class="">コンテンツでは、これらのテキストの間隔の値を用いることは必須ではない。要件はあくまで、制作されたテキストの間隔を利用者が上書きした場合に、コンテンツ又は機能が失われないことである。</p></div>
 
- <div class="note" role="note" id="issue-container-generatedID-11"><div role="heading" class="note-title marker" id="h-note-11" aria-level="5"><span>注記 2</span></div><p class="">Writing systems for some languages use different text spacing settings, such as paragraph start indent. Authors are encouraged to follow locally available guidance for improving readability and legibility of text in their writing system.</p></div>
+ <div class="note" role="note" id="issue-container-generatedID-11"><div role="heading" class="note-title marker" id="h-note-11" aria-level="5"><span>注記 2</span></div><p class="">一部の言語の記述体系では、例えば段落開始のインデントのように、テキストの間隔について異なる設定が用いられている。コンテンツ制作者は、テキストの可読性及び文字の識別性を高めるために、そうした言語記述体系のローカル指針に従うことが推奨される。</p></div>
  
 </section>
 


### PR DESCRIPTION
達成基準 1.4.12 テキストの間隔
で新たに追加された注記を翻訳しました。

達成基準 1.4.8 視覚的提示
の注記に近いないようなので、先行してマージされた PR #46 に合わせて、[59e8161](https://github.com/waic/wcag22/pull/58/commits/59e8161c1d89bd70265d25baca74602a2a5f9c48) と [1e8a017](https://github.com/waic/wcag22/pull/58/commits/1e8a017a440eaab748b8770d2670bebec5b66839) で修正を加えています。