### PR TITLE
WCAG 2.2：6 用語集 encloses (訳注の追加)

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -2683,7 +2683,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 <dd class="new"><p class="change">[New]</p>
    					
    <p>solidly bounds or surrounds</p>
-   <div class="note"><div role="heading" class="note-title marker" aria-level="5"><span>訳注</span></div><p>この用語は、WCAG 2.2 の 2023 年 10 月 5 日付けの勧告においては、削除されるべきであるにもかかわらず残っているものであり、いずれ正式に削除される予定である。</p></div>
+   <div class="note"><div role="heading" class="note-title marker" aria-level="3"><span>訳注</span></div><p>この用語は、この文書内でどこからも参照されていないものであり、正式に削除される予定である。</p></div>
 </dd>
 
             

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -2683,7 +2683,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 <dd class="new"><p class="change">[New]</p>
    					
    <p>solidly bounds or surrounds</p>
-   				
+   <div class="note"><div role="heading" class="note-title marker" aria-level="5"><span>訳注</span></div><p>この用語は、WCAG 2.2 の 2023 年 10 月 5 日付けの勧告においては、削除されるべきであるにもかかわらず残っているものであり、いずれ正式に削除される予定である。</p></div>
 </dd>
 
             


### PR DESCRIPTION
issue #23 対応として、翻訳はせずに、訳注を追加する形にしています。

W3C 側で
https://github.com/w3c/wcag/issues/3510
の議論があり、
https://github.com/w3c/wcag/pull/3636
がマージされれば、この用語は削除されると思います。
ただ、この訳注の中では、具体的な W3C 側のプルリクエスト（へのリンク）は記述せず、general な書きかたにしてあります。