### PR TITLE
未訳の解説書に冒頭訳註を追加

### DIFF
--- a/understanding/abbreviations.html
+++ b/understanding/abbreviations.html
@@ -71,6 +71,9 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+         
+         <!-- 日本語訳されるまでの一時的な注記 -->
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 3.1.4:</span>Abbreviations (Level AAA)
             </h1>

--- a/understanding/about.html
+++ b/understanding/about.html
@@ -109,7 +109,9 @@
          		
          
          <main id="main" class="main-content standalone-resource__main">
-            			
+
+         <!-- 日本語訳されるまでの一時的な注記 -->
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             
             <h1 id="title" class="title p-name">About WCAG Understanding Documents</h1>
             

--- a/understanding/adaptable.html
+++ b/understanding/adaptable.html
@@ -62,6 +62,9 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <!-- 日本語訳されるまでの一時的な注記 -->
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				Guideline 1.3:</span>Adaptable
             </h1>

--- a/understanding/animation-from-interactions.html
+++ b/understanding/animation-from-interactions.html
@@ -68,6 +68,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.3.3:</span>Animation from Interactions (Level AAA)
             </h1>

--- a/understanding/audio-control.html
+++ b/understanding/audio-control.html
@@ -71,6 +71,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.4.2:</span>Audio Control (Level A)
             </h1>

--- a/understanding/audio-description-or-media-alternative-prerecorded.html
+++ b/understanding/audio-description-or-media-alternative-prerecorded.html
@@ -72,6 +72,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.2.3:</span>Audio Description or Media Alternative (Prerecorded) (Level A)
             </h1>

--- a/understanding/audio-description-prerecorded.html
+++ b/understanding/audio-description-prerecorded.html
@@ -72,6 +72,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.2.5:</span>Audio Description (Prerecorded) (Level AA)
             </h1>

--- a/understanding/audio-only-and-video-only-prerecorded.html
+++ b/understanding/audio-only-and-video-only-prerecorded.html
@@ -69,6 +69,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.2.1:</span>Audio-only and Video-only (Prerecorded) (Level A)
             </h1>

--- a/understanding/audio-only-live.html
+++ b/understanding/audio-only-live.html
@@ -68,6 +68,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.2.9:</span>Audio-only (Live) (Level AAA)
             </h1>

--- a/understanding/bypass-blocks.html
+++ b/understanding/bypass-blocks.html
@@ -69,6 +69,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.4.1:</span>Bypass Blocks (Level A)
             </h1>

--- a/understanding/captions-live.html
+++ b/understanding/captions-live.html
@@ -71,6 +71,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.2.4:</span>Captions (Live) (Level AA)
             </h1>

--- a/understanding/captions-prerecorded.html
+++ b/understanding/captions-prerecorded.html
@@ -72,6 +72,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.2.2:</span>Captions (Prerecorded) (Level A)
             </h1>

--- a/understanding/change-on-request.html
+++ b/understanding/change-on-request.html
@@ -72,6 +72,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 3.2.5:</span>Change on Request (Level AAA)
             </h1>

--- a/understanding/character-key-shortcuts.html
+++ b/understanding/character-key-shortcuts.html
@@ -69,6 +69,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.1.4:</span>Character Key Shortcuts (Level A)
             </h1>

--- a/understanding/compatible.html
+++ b/understanding/compatible.html
@@ -62,6 +62,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				Guideline 4.1:</span>Compatible
             </h1>

--- a/understanding/concurrent-input-mechanisms.html
+++ b/understanding/concurrent-input-mechanisms.html
@@ -71,6 +71,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.5.6:</span>Concurrent Input Mechanisms (Level AAA)
             </h1>

--- a/understanding/conformance.html
+++ b/understanding/conformance.html
@@ -67,6 +67,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1>Understanding Conformance</h1>
             <div>
                

--- a/understanding/consistent-identification.html
+++ b/understanding/consistent-identification.html
@@ -70,6 +70,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 3.2.4:</span>Consistent Identification (Level AA)
             </h1>

--- a/understanding/consistent-navigation.html
+++ b/understanding/consistent-navigation.html
@@ -71,6 +71,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 3.2.3:</span>Consistent Navigation (Level AA)
             </h1>

--- a/understanding/content-on-hover-or-focus.html
+++ b/understanding/content-on-hover-or-focus.html
@@ -68,6 +68,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.4.13:</span>Content on Hover or Focus (Level AA)
             </h1>

--- a/understanding/contrast-enhanced.html
+++ b/understanding/contrast-enhanced.html
@@ -71,6 +71,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.4.6:</span>Contrast (Enhanced) (Level AAA)
             </h1>

--- a/understanding/contrast-minimum.html
+++ b/understanding/contrast-minimum.html
@@ -71,6 +71,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.4.3:</span>Contrast (Minimum) (Level AA)
             </h1>

--- a/understanding/distinguishable.html
+++ b/understanding/distinguishable.html
@@ -62,6 +62,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				Guideline 1.4:</span>Distinguishable
             </h1>

--- a/understanding/documenting-accessibility-support.html
+++ b/understanding/documenting-accessibility-support.html
@@ -56,6 +56,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1>Documenting Accessibility Support for Uses of a Web Technology</h1>
             <div>
                		

--- a/understanding/enough-time.html
+++ b/understanding/enough-time.html
@@ -62,6 +62,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				Guideline 2.2:</span>Enough Time
             </h1>

--- a/understanding/error-identification.html
+++ b/understanding/error-identification.html
@@ -68,6 +68,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 3.3.1:</span>Error Identification (Level A)
             </h1>

--- a/understanding/error-prevention-all.html
+++ b/understanding/error-prevention-all.html
@@ -69,6 +69,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 3.3.6:</span>Error Prevention (All) (Level AAA)
             </h1>

--- a/understanding/error-prevention-legal-financial-data.html
+++ b/understanding/error-prevention-legal-financial-data.html
@@ -70,6 +70,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 3.3.4:</span>Error Prevention (Legal, Financial, Data) (Level AA)
             </h1>

--- a/understanding/error-suggestion.html
+++ b/understanding/error-suggestion.html
@@ -70,6 +70,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 3.3.3:</span>Error Suggestion (Level AA)
             </h1>

--- a/understanding/extended-audio-description-prerecorded.html
+++ b/understanding/extended-audio-description-prerecorded.html
@@ -71,6 +71,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.2.7:</span>Extended Audio Description (Prerecorded) (Level AAA)
             </h1>

--- a/understanding/focus-order.html
+++ b/understanding/focus-order.html
@@ -70,6 +70,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.4.3:</span>Focus Order (Level A)
             </h1>

--- a/understanding/focus-visible.html
+++ b/understanding/focus-visible.html
@@ -71,6 +71,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.4.7:</span>Focus Visible (Level AA)
             </h1>

--- a/understanding/headings-and-labels.html
+++ b/understanding/headings-and-labels.html
@@ -72,6 +72,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.4.6:</span>Headings and Labels (Level AA)
             </h1>

--- a/understanding/help.html
+++ b/understanding/help.html
@@ -70,6 +70,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 3.3.5:</span>Help (Level AAA)
             </h1>

--- a/understanding/identify-input-purpose.html
+++ b/understanding/identify-input-purpose.html
@@ -72,6 +72,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.3.5:</span>Identify Input Purpose (Level AA)
             </h1>

--- a/understanding/identify-purpose.html
+++ b/understanding/identify-purpose.html
@@ -68,6 +68,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.3.6:</span>Identify Purpose (Level AAA)
             </h1>

--- a/understanding/images-of-text-no-exception.html
+++ b/understanding/images-of-text-no-exception.html
@@ -72,6 +72,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.4.9:</span>Images of Text (No Exception) (Level AAA)
             </h1>

--- a/understanding/images-of-text.html
+++ b/understanding/images-of-text.html
@@ -72,6 +72,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.4.5:</span>Images of Text (Level AA)
             </h1>

--- a/understanding/info-and-relationships.html
+++ b/understanding/info-and-relationships.html
@@ -69,6 +69,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.3.1:</span>Info and Relationships (Level A)
             </h1>

--- a/understanding/input-assistance.html
+++ b/understanding/input-assistance.html
@@ -62,6 +62,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				Guideline 3.3:</span>Input Assistance
             </h1>

--- a/understanding/input-modalities.html
+++ b/understanding/input-modalities.html
@@ -62,6 +62,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				Guideline 2.5:</span>Input Modalities
             </h1>

--- a/understanding/interruptions.html
+++ b/understanding/interruptions.html
@@ -71,6 +71,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.2.4:</span>Interruptions (Level AAA)
             </h1>

--- a/understanding/intro.html
+++ b/understanding/intro.html
@@ -59,6 +59,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1>Introduction to Understanding WCAG </h1>
             <div>
                		

--- a/understanding/keyboard-accessible.html
+++ b/understanding/keyboard-accessible.html
@@ -63,6 +63,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				Guideline 2.1:</span>Keyboard Accessible
             </h1>

--- a/understanding/keyboard-no-exception.html
+++ b/understanding/keyboard-no-exception.html
@@ -70,6 +70,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.1.3:</span>Keyboard (No Exception) (Level AAA)
             </h1>

--- a/understanding/keyboard.html
+++ b/understanding/keyboard.html
@@ -68,6 +68,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.1.1:</span>Keyboard (Level A)
             </h1>

--- a/understanding/label-in-name.html
+++ b/understanding/label-in-name.html
@@ -72,6 +72,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.5.3:</span>Label in Name (Level A)
             </h1>

--- a/understanding/labels-or-instructions.html
+++ b/understanding/labels-or-instructions.html
@@ -70,6 +70,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 3.3.2:</span>Labels or Instructions (Level A)
             </h1>

--- a/understanding/language-of-page.html
+++ b/understanding/language-of-page.html
@@ -69,6 +69,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 3.1.1:</span>Language of Page (Level A)
             </h1>

--- a/understanding/language-of-parts.html
+++ b/understanding/language-of-parts.html
@@ -72,6 +72,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 3.1.2:</span>Language of Parts (Level AA)
             </h1>

--- a/understanding/link-purpose-in-context.html
+++ b/understanding/link-purpose-in-context.html
@@ -72,6 +72,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.4.4:</span>Link Purpose (In Context) (Level A)
             </h1>

--- a/understanding/link-purpose-link-only.html
+++ b/understanding/link-purpose-link-only.html
@@ -72,6 +72,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.4.9:</span>Link Purpose (Link Only) (Level AAA)
             </h1>

--- a/understanding/location.html
+++ b/understanding/location.html
@@ -71,6 +71,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.4.8:</span>Location (Level AAA)
             </h1>

--- a/understanding/low-or-no-background-audio.html
+++ b/understanding/low-or-no-background-audio.html
@@ -70,6 +70,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.4.7:</span>Low or No Background Audio (Level AAA)
             </h1>

--- a/understanding/meaningful-sequence.html
+++ b/understanding/meaningful-sequence.html
@@ -70,6 +70,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.3.2:</span>Meaningful Sequence (Level A)
             </h1>

--- a/understanding/media-alternative-prerecorded.html
+++ b/understanding/media-alternative-prerecorded.html
@@ -72,6 +72,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.2.8:</span>Media Alternative (Prerecorded) (Level AAA)
             </h1>

--- a/understanding/motion-actuation.html
+++ b/understanding/motion-actuation.html
@@ -72,6 +72,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.5.4:</span>Motion Actuation (Level A)
             </h1>

--- a/understanding/multiple-ways.html
+++ b/understanding/multiple-ways.html
@@ -70,6 +70,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.4.5:</span>Multiple Ways (Level AA)
             </h1>

--- a/understanding/name-role-value.html
+++ b/understanding/name-role-value.html
@@ -72,6 +72,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 4.1.2:</span>Name, Role, Value (Level A)
             </h1>

--- a/understanding/navigable.html
+++ b/understanding/navigable.html
@@ -62,6 +62,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				Guideline 2.4:</span>Navigable
             </h1>

--- a/understanding/no-keyboard-trap.html
+++ b/understanding/no-keyboard-trap.html
@@ -71,6 +71,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.1.2:</span>No Keyboard Trap (Level A)
             </h1>

--- a/understanding/no-timing.html
+++ b/understanding/no-timing.html
@@ -70,6 +70,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.2.3:</span>No Timing (Level AAA)
             </h1>

--- a/understanding/non-text-content.html
+++ b/understanding/non-text-content.html
@@ -66,6 +66,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.1.1:</span>Non-text Content (Level A)
             </h1>

--- a/understanding/non-text-contrast.html
+++ b/understanding/non-text-contrast.html
@@ -71,6 +71,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.4.11:</span>Non-text Contrast (Level AA)
             </h1>

--- a/understanding/on-focus.html
+++ b/understanding/on-focus.html
@@ -67,6 +67,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 3.2.1:</span>On Focus (Level A)
             </h1>

--- a/understanding/on-input.html
+++ b/understanding/on-input.html
@@ -70,6 +70,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 3.2.2:</span>On Input (Level A)
             </h1>

--- a/understanding/orientation.html
+++ b/understanding/orientation.html
@@ -72,6 +72,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.3.4:</span>Orientation (Level AA)
             </h1>

--- a/understanding/page-titled.html
+++ b/understanding/page-titled.html
@@ -72,6 +72,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.4.2:</span>Page Titled (Level A)
             </h1>

--- a/understanding/parsing.html
+++ b/understanding/parsing.html
@@ -66,6 +66,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 4.1.1:</span>Parsing (Obsolete and removed) (Level )
             </h1>

--- a/understanding/pause-stop-hide.html
+++ b/understanding/pause-stop-hide.html
@@ -71,6 +71,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.2.2:</span>Pause, Stop, Hide (Level A)
             </h1>

--- a/understanding/pointer-cancellation.html
+++ b/understanding/pointer-cancellation.html
@@ -70,6 +70,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.5.2:</span>Pointer Cancellation (Level A)
             </h1>

--- a/understanding/pointer-gestures.html
+++ b/understanding/pointer-gestures.html
@@ -67,6 +67,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.5.1:</span>Pointer Gestures (Level A)
             </h1>

--- a/understanding/predictable.html
+++ b/understanding/predictable.html
@@ -62,6 +62,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				Guideline 3.2:</span>Predictable
             </h1>

--- a/understanding/pronunciation.html
+++ b/understanding/pronunciation.html
@@ -67,6 +67,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 3.1.6:</span>Pronunciation (Level AAA)
             </h1>

--- a/understanding/re-authenticating.html
+++ b/understanding/re-authenticating.html
@@ -69,6 +69,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.2.5:</span>Re-authenticating (Level AAA)
             </h1>

--- a/understanding/readable.html
+++ b/understanding/readable.html
@@ -62,6 +62,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				Guideline 3.1:</span>Readable
             </h1>

--- a/understanding/reading-level.html
+++ b/understanding/reading-level.html
@@ -71,6 +71,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 3.1.5:</span>Reading Level (Level AAA)
             </h1>

--- a/understanding/refer-to-wcag.html
+++ b/understanding/refer-to-wcag.html
@@ -62,6 +62,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1>How to Refer to WCAG  from Other Documents</h1>
             <div>
                		

--- a/understanding/reflow.html
+++ b/understanding/reflow.html
@@ -72,6 +72,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.4.10:</span>Reflow (Level AA)
             </h1>

--- a/understanding/resize-text.html
+++ b/understanding/resize-text.html
@@ -72,6 +72,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.4.4:</span>Resize Text (Level AA)
             </h1>

--- a/understanding/section-headings.html
+++ b/understanding/section-headings.html
@@ -71,6 +71,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.4.10:</span>Section Headings (Level AAA)
             </h1>

--- a/understanding/seizures-and-physical-reactions.html
+++ b/understanding/seizures-and-physical-reactions.html
@@ -62,6 +62,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				Guideline 2.3:</span>Seizures and Physical Reactions
             </h1>

--- a/understanding/sensory-characteristics.html
+++ b/understanding/sensory-characteristics.html
@@ -70,6 +70,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.3.3:</span>Sensory Characteristics (Level A)
             </h1>

--- a/understanding/sign-language-prerecorded.html
+++ b/understanding/sign-language-prerecorded.html
@@ -71,6 +71,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.2.6:</span>Sign Language (Prerecorded) (Level AAA)
             </h1>

--- a/understanding/status-messages.html
+++ b/understanding/status-messages.html
@@ -67,6 +67,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 4.1.3:</span>Status Messages (Level AA)
             </h1>

--- a/understanding/target-size-enhanced.html
+++ b/understanding/target-size-enhanced.html
@@ -71,6 +71,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.5.5:</span>Target Size (Enhanced) (Level AAA)
             </h1>

--- a/understanding/text-alternatives.html
+++ b/understanding/text-alternatives.html
@@ -63,6 +63,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				Guideline 1.1:</span>Text Alternatives
             </h1>

--- a/understanding/text-spacing.html
+++ b/understanding/text-spacing.html
@@ -72,6 +72,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.4.12:</span>Text Spacing (Level AA)
             </h1>

--- a/understanding/three-flashes-or-below-threshold.html
+++ b/understanding/three-flashes-or-below-threshold.html
@@ -68,6 +68,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.3.1:</span>Three Flashes or Below Threshold (Level A)
             </h1>

--- a/understanding/three-flashes.html
+++ b/understanding/three-flashes.html
@@ -71,6 +71,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.3.2:</span>Three Flashes (Level AAA)
             </h1>

--- a/understanding/time-based-media.html
+++ b/understanding/time-based-media.html
@@ -62,6 +62,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				Guideline 1.2:</span>Time-based Media
             </h1>

--- a/understanding/timeouts.html
+++ b/understanding/timeouts.html
@@ -68,6 +68,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.2.6:</span>Timeouts (Level AAA)
             </h1>

--- a/understanding/timing-adjustable.html
+++ b/understanding/timing-adjustable.html
@@ -68,6 +68,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 2.2.1:</span>Timing Adjustable (Level A)
             </h1>

--- a/understanding/understanding-act-rules.html
+++ b/understanding/understanding-act-rules.html
@@ -61,6 +61,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1>Understanding Test Rules for WCAG Success Criteria</h1>
             <div>
                		

--- a/understanding/understanding-metadata.html
+++ b/understanding/understanding-metadata.html
@@ -55,6 +55,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1>Understanding Metadata</h1>
             <div>
                		

--- a/understanding/understanding-techniques.html
+++ b/understanding/understanding-techniques.html
@@ -66,6 +66,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1>Understanding Techniques for WCAG Success Criteria</h1>
             <div>
                		

--- a/understanding/unusual-words.html
+++ b/understanding/unusual-words.html
@@ -71,6 +71,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 3.1.3:</span>Unusual Words (Level AAA)
             </h1>

--- a/understanding/use-of-color.html
+++ b/understanding/use-of-color.html
@@ -67,6 +67,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.4.1:</span>Use of Color (Level A)
             </h1>

--- a/understanding/visual-presentation.html
+++ b/understanding/visual-presentation.html
@@ -71,6 +71,8 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
+
+         <div><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
             <h1><span class="standalone-resource__type-of-guidance">Understanding 
                   				SC 1.4.8:</span>Visual Presentation (Level AAA)
             </h1>


### PR DESCRIPTION
WCAG 2.2 解説書の、新規達成基準以外の各ページに対して、冒頭 ( `<main>` の直下) に、訳注を追加しました。

closes #333 