### PR TITLE
waic_link.jsの移植

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -4351,4 +4351,4 @@ function hidePanel(panel) {
   panel.hidden = true;
   panel.classList.remove("docked");
 }
-})()</script><script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script></body></html>
+})()</script><script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script><script src="waic_link.js"></script></body></html>

--- a/guidelines/waic_link.js
+++ b/guidelines/waic_link.js
@@ -1,0 +1,27 @@
+const trNote = "この文書内にあるリンクのうち、「Understanding WCAG 2.2」へのリンクについては、WAIC の公開する日本語版にリンク先を追加しています。WAIC の日本語訳は、 W3C の公開する英語版より内容が古い可能性がありますのでご注意ください。";
+const jaLinkText = '[日本語訳]';
+const jaLinkTitleSuffix = 'の日本語訳';
+const taregtUrlString = ['Understanding', 'Techniques'];
+
+document.addEventListener('DOMContentLoaded', function(){
+	const lastTrNote = document.querySelector("aside.trnote>p:last-child");
+	if(lastTrNote) lastTrNote.textContent = trNote;
+
+	const w3cDocumentAnchors = document.querySelectorAll("a[href*=https\\:\\/\\/www\\.w3\\.org\\/WAI\\/WCAG22]");
+	for(let i = 0; i < w3cDocumentAnchors.length; i++){
+		const anchor = w3cDocumentAnchors[i];
+		const href = anchor.getAttribute('href');
+		taregtUrlString.forEach(taregtString => {
+			if(href.indexOf(taregtString)!=-1 ){
+				const jaLinkUrl = href.replace('\/\/www.w3.org\/WAI\/WCAG22\/', '//waic.jp/translations/WCAG22/');
+				const jaLinkTitle = '"' + anchor.textContent + '"' + jaLinkTitleSuffix;
+				const jaAnchor = document.createElement('a');
+				jaAnchor.setAttribute('href', jaLinkUrl);
+				jaAnchor.setAttribute('title', jaLinkTitle);
+				jaAnchor.textContent = jaLinkText;
+				anchor.parentNode.insertBefore(jaAnchor, anchor.nextSibling);
+				jaAnchor.parentNode.insertBefore(document.createTextNode(" "), jaAnchor);
+			}
+		})
+	}
+});

--- a/guidelines/waic_link.js
+++ b/guidelines/waic_link.js
@@ -1,7 +1,7 @@
 const trNote = "この文書内にあるリンクのうち、「Understanding WCAG 2.2」へのリンクについては、WAIC の公開する日本語版にリンク先を追加しています。WAIC の日本語訳は、 W3C の公開する英語版より内容が古い可能性がありますのでご注意ください。";
 const jaLinkText = '[日本語訳]';
 const jaLinkTitleSuffix = 'の日本語訳';
-const taregtUrlString = ['Understanding', 'Techniques'];
+const taregtUrlString = ['Understanding'];
 
 document.addEventListener('DOMContentLoaded', function(){
 	const lastTrNote = document.querySelector("aside.trnote>p:last-child");


### PR DESCRIPTION
Close #189

@caztcha @bakera 

移植しましたのでレビューをお願いします。

* <https://github.com/waic/wcag21/blob/master/guidelines/waic_link.js>からWCAG21をWCAG22に置換
* あわせてguidelines/index.html に`<script>`を追加