### PR TITLE
達成基準 3.1.4 略語 / 用語のリンク修正

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -1663,7 +1663,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG22/Understanding/abbreviations.html">Understanding Abbreviations</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG22/quickref/#abbreviations">How to Meet Abbreviations</a></div><p class="conformance-level">(レベル AAA)</p>
    
-   <p><a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-mechanism-9" title="結果を得るためのプロセス又は手法。">略語</a>の元の語、又は意味を特定する<a href="#dfn-abbreviations" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-abbreviations-1" title="単語、語句、又は名称の短縮形で、その略語が言語の一部になっていないもの。">メカニズム</a>が利用できる。</p>
+   <p><a href="#dfn-abbreviations" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-abbreviations-1" title="単語、語句、又は名称の短縮形で、その略語が言語の一部になっていないもの。">略語</a>の元の語、又は意味を特定する<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-mechanism-9" title="結果を得るためのプロセス又は手法。">メカニズム</a>が利用できる。</p>
    
 </section>
             


### PR DESCRIPTION
closes #362 

WCAG 2.2 本体の、達成基準 3.1.4 略語 において、用語へのリンクが誤っているので修正しました。