### PR TITLE
WCAG 2.2 日本語訳の用語集「相対輝度 (relative luminance)」リンク切れ修正

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -3113,7 +3113,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
    
    <div class="note" role="note" id="issue-container-generatedID-140"><div role="heading" class="note-title marker" id="h-note-140" aria-level="3"><span>注記 5</span></div><p class="">コントラストと閃光を検証する際に、この計算を自動で行うツールが利用できる。</p></div>
    
-   <div class="note" role="note" id="issue-container-generatedID-141"><div role="heading" class="note-title marker" id="h-note-141" aria-level="3"><span>注記 6</span></div><p class=""><a href="relative-luminance.html">MathML を用いて相対輝度の定義を与える別のページ</a>でもこの計算式を表示できる。</p></div>
+   <div class="note" role="note" id="issue-container-generatedID-141"><div role="heading" class="note-title marker" id="h-note-141" aria-level="3"><span>注記 6</span></div><p class=""><a href="https://www.w3.org/TR/WCAG22/relative-luminance.html">MathML を用いて相対輝度の定義を与える別のページ</a>でもこの計算式を表示できる。</p></div>
    
 </dd>
 


### PR DESCRIPTION
closes #363 

WCAG 2.2 本体の、用語集「相対輝度 (relative luminance)」において、リンク切れがあるので修正しました。