### PR TITLE
他の文書からの WCAG の参照方法 の翻訳

### DIFF
--- a/understanding/refer-to-wcag.html
+++ b/understanding/refer-to-wcag.html
@@ -1,18 +1,16 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="ja" xml:lang="ja">
    <head>
       <meta charset="UTF-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <title>How to Refer to WCAG  from Other Documents | WAI | W3C</title>
+      <title>他の文書からの WCAG の参照方法 | WAI | W3C</title>
       <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css" />
       <link rel="stylesheet" href="base.css" />
-      <!-- 日本語訳されるまでの一時的なスクリプト -->
-      <script src="untranslated-note.js"></script>
    </head>
    <body dir="ltr"><a href="#main" class="button button--skip-link">Skip to content</a><div class="minimal-header-container default-grid">
          <div class="minimal-header" id="site-header">
-            <div class="minimal-header-name"><a href="https://w3c.github.io/wcag/understanding/">WCAG 2.2 Understanding Docs</a></div>
-            <div class="minimal-header-subtitle">Informative explanations, not required to meet WCAG</div><a class="minimal-header-link" href="https://w3c.github.io/wcag/understanding/about">About WCAG Understanding Docs</a><div class="minimal-header-logo"><a href="http://w3.org/" aria-label="W3C">
+            <div class="minimal-header-name"><a href="https://waic.jp/translations/WCAG22/Understanding/">WCAG 2.2 解説書</a></div>
+            <div class="minimal-header-subtitle">Informative explanations, not required to meet WCAG</div><a class="minimal-header-link" href="https://waic.jp/translations/WCAG22/Understanding/about">WCAG解説書について</a><div class="minimal-header-logo"><a href="http://w3.org/" aria-label="W3C">
                   <svg xmlns="http://www.w3.org/2000/svg" height="2em" viewBox="0 0 91.968 44" style="margin: 0.75em 0 0.75em 0.5em">
                      <g fill-rule="evenodd" fill="none">
                         <path fill="#015a9c" d="M-.231-.21h92.917v44.659H-.23z"></path>
@@ -37,10 +35,10 @@
             <nav class="nav standalone-resource-pager" aria-label="Understanding Docs">
                <ul>
                   <li class="nav__item"><a href=".">
-                        								All Understanding Docs
+                        								目次
                         							</a></li>
                   <li class="nav__item"></li>
-                  <li class="nav__item"><a href="documenting-accessibility-support">Next : Documenting Accessibility Support for Uses of a Web Technology
+                  <li class="nav__item"><a href="documenting-accessibility-support">次: ウェブコンテンツ技術の使用法のアクセシビリティ サポートを文書化する
                         <svg focusable="false" aria-hidden="true" class="icon-arrow-right-thin pager-icon" viewBox="0 0 16 16">
                            <path fill-rule="evenodd" d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"></path>
                         </svg></a></li>
@@ -51,112 +49,91 @@
       <div class="default-grid with-gap leftcol">
          <aside class="box nav-hack sidebar standalone-resource__sidebar ">
             <nav>
-               <header class="box-h ">Page Contents</header>
+               <header class="box-h ">このページの内容</header>
                <div class="box-i">
                   <ul>
-                     <li><a href="#conformance-referencing-information">Information references</a></li>
-                     <li><a href="#conformance-referencing-should">When referring to WCAG 2.1 from another standard with a "should" statement</a></li>
-                     <li><a href="#conformance-referencing-must">When referring to WCAG 2.1 from another standard with a "shall or must" statement</a></li>
-                     <li><a href="#conformance-referencing-examples">Examples</a></li>
-                     <li><a href="#conformance-referencing-support">Referring to content from WCAG support documents</a></li>
+                     <li><a href="#conformance-referencing-information">情報提供を目的にして参照する場合</a></li>
+                     <li><a href="#conformance-referencing-should">他の標準規格から WCAG 2.2 を「推奨」要件として参照する場合</a></li>
+                     <li><a href="#conformance-referencing-must">他の標準規格から WCAG 2.2 を「必須」要件として参照する場合</a></li>
+                     <li><a href="#conformance-referencing-examples">事例</a></li>
+                     <li><a href="#conformance-referencing-support">WCAG 関連文書のコンテンツへの参照</a></li>
                   </ul>
                </div>
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
 
-         <!-- 日本語訳されるまでの一時的な注記 -->
-         <div class="untranslated-note"><p>このWCAG 2.2 解説書の日本語訳は作業中となっています。WCAG 2.1 解説書の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Understanding/">WCAG 2.1 解説書</a> ]</p></div>
-            <h1>How to Refer to WCAG  from Other Documents</h1>
+            <h1>他の文書からの WCAG の参照方法</h1>
             <div>
                		
                		
-               <p>The following examples show how to reference WCAG 2.1 in various situations. For additional
-                  guidance, see <a href="https://www.w3.org/WAI/intro/linking.html">Referencing and Linking to WAI Guidelines and Technical Documents</a>.
+               <p>以下の事例は、さまざまな状況における WCAG 2.2 の参照方法を示すものである。他のガイダンスについては、<a href="https://www.w3.org/WAI/intro/linking.html">Referencing and Linking to WAI Guidelines and Technical Documents</a> を参照のこと。
                </p>
                		
-               <p> Please note that the following language for referencing WCAG 2.1 can be inserted
-                  into your own documents. 
+               <p>WCAG 2.2 を参照するために用いる次の言葉を文書に挿入することが可能である。
                </p>
                		
                <section id="conformance-referencing-information">
                   			
-                  <h2>Information references</h2>
+                  <h2>情報提供を目的にして参照する場合</h2>
                   			
-                  <p>When referencing WCAG 2.1 in an informational fashion, the following format can be
-                     used.
+                  <p>WCAG 2.2 を情報提供という意味で参照する際には、次のフォーマットを使用することができる。
                   </p>
                   			
-                  <p><em>Web Content Accessibility Guidelines 2.0, W3C World Wide Web Consortium Recommendation
-                        XX Month Year (https://www.w3.org/TR/YYYY/REC-WCAG21-YYYYMMDD/, Latest version at
-                        https://www.w3.org/TR/WCAG21/)</em></p>
+                  <p><em>Web Content Accessibility Guidelines 2.2, W3C World Wide Web Consortium Recommendation XX Month Year (https://www.w3.org/TR/YYYY/REC-WCAG22-YYYYMMDD/, Latest version at https://www.w3.org/TR/WCAG22/)</em></p>
                   		
                </section>
                		
                <section id="conformance-referencing-should">
                   			
-                  <h2>When referring to WCAG 2.1 from another standard with a "should" statement</h2>
+                  <h2>他の標準規格から WCAG 2.2 を「推奨」要件として参照する場合</h2>
                   			
-                  <p>When referencing WCAG 2.1 from within a <strong>should</strong> statement in a standard (or advisory statement in a regulation), then the full WCAG
-                     2.1 should be referenced. This would mean that all three levels of WCAG 2.1 should
-                     be considered but that none are required. The format for referencing WCAG 2.1 from
-                     a "should" statement therefore, is:
+                  <p>標準規格 (又は、規定における推奨) で、<strong>推奨</strong>要件の中で WCAG 2.2 を参照する際には、WCAG 2.2 全体を参照するのが望ましい。これは、WCAG 2.2 の三つのレベルすべてを考慮すべきだが、どれも必須ではないという意味になる。そのため、推奨要件の中で WCAG 2.2 を参照する際のフォーマットは次のようになる:
                   </p>
                   			
-                  <p><em>Web Content Accessibility Guidelines 2.0, W3C World Wide Web Consortium Recommendation
-                        XX Month Year. (https://www.w3.org/TR/YYYY/REC-WCAG21-YYYYMMDD/)</em></p>
+                  <p><em>Web Content Accessibility Guidelines 2.2, W3C World Wide Web Consortium Recommendation XX Month Year. (https://www.w3.org/TR/YYYY/REC-WCAG22-YYYYMMDD/)</em></p>
                   		
                </section>
                		
                <section id="conformance-referencing-must">
                   			
-                  <h2>When referring to WCAG 2.1 from another standard with a "shall or must" statement</h2>
+                  <h2>他の標準規格から WCAG 2.2 を「必須」要件として参照する場合</h2>
                   			
-                  <p>When citing WCAG 2.1 as part of a requirement (e.g., a <strong>shall or must </strong> statement in a standard or regulation), the reference must include the specific parts
-                     of WCAG 2.1 that are intended to be required. When referencing WCAG 2.1 in this manner,
-                     the following rules apply: 
+                  <p>WCAG 2.2 を要件 (例: 標準規格又は規定の<strong>必須</strong>要件) の一部として引用する際、WCAG 2.2 の中で必須とする部分を含めなければならない。この方法で WCAG 2.2 を参照する際には、次のルールが適用される:
                   </p>
                   			
                   <ol class="enumar">
                      				
                      <li>
                         					
-                        <p>Conformance at any level of WCAG 2.1 requires that all of the Level A Success Criteria
-                           be met. References to WCAG 2.1 conformance cannot be for any subset of Level A. 
+                        <p>どのレベルであれ、WCAG 2.2 に適合するには、すべてのレベル A の達成基準に適合する必要がある。WCAG 2.2 への適合の参照は、部分的なレベル A 適合であってはならない。
                         </p>
                         				
                      </li>
                      				
                      <li>
                         					
-                        <p>Beyond Level A, a "shall or must" reference may include any subset of provisions in
-                           Levels AA and AAA. For example, "<em>all of Level A and [some specific list of Success Criteria in Level AA and Level AAA]</em>" be met. 
+                        <p>レベル A 以上であれば、「必須」要件にレベル AA 及び AAA の要件を部分的に加えてもよい。例えば、「<em>すべてのレベル A 及び [レベル AA 及び AAA 達成基準のある特定のリスト]</em>」に適合しなければならない。
                         </p>
                         				
                      </li>
                      				
                      <li>
                         					
-                        <p>If Level AA conformance to WCAG 2.1 is specified, then all Level A and all Level AA
-                           Success Criteria must be met.
+                        <p>WCAG 2.2 へのレベル AA 適合が指定されている場合は、すべてのレベル A 及びすべてのレベル AA 達成基準に適合しなければならない。
                         </p>
                         				
                      </li>
                      				
                      <li>
                         					
-                        <p>If Level AAA conformance to WCAG 2.1 is specified, then all Level A, all Level AA,
-                           and all Level AAA Success Criteria must be met.
+                        <p>WCAG 2.2 へのレベル AAA 適合が指定されている場合は、すべてのレベル A、すべてのレベル AA 及びすべてのレベル AAA 達成基準に適合しなければならない。
                         </p>
                         					
-                        <p class="prefix"><em>Note 1: </em>It is not recommended that Level AAA conformance ever be required for entire sites
-                           as a general policy because it is not possible to satisfy all Level AAA Success Criteria
-                           for some content. 
+                        <p class="prefix"><em>注記 1: </em>レベル AAA 適合をサイト全体の基本的なポリシーとして要求することは推奨しない。なぜなら、コンテンツによっては、レベル AAA の達成基準をすべて満たすことができないからである。
                         </p>
                         					
-                        <p class="prefix"><em>Note 2: </em>The sets of Success Criteria defined in WCAG are interdependent and individual Success
-                           Criteria rely on each other's definitions in ways which may not be immediately obvious
-                           to the reader. Any set of Success Criteria must include all of the Level A provisions.
+                        <p class="prefix"><em>注記 2: </em>WCAG で定義されている達成基準一式は相互依存しており、個々の達成基準は読者には一見して分からないような形でお互いの定義に依存している。どんな達成基準一式であっても、すべてのレベル A 達成基準が含まれていなければならない。
                         </p>
                         				
                      </li>
@@ -167,47 +144,35 @@
                		
                <section id="conformance-referencing-examples">
                   			
-                  <h2>Examples</h2>
+                  <h2>事例</h2>
                   			
-                  <p><strong>To cite only the Level A Success Criteria (Single-A conformance):</strong></p>
+                  <p><strong>レベル A 達成基準のみを引用する場合 (レベル A 適合):</strong></p>
                   			
-                  <p><em>Web Content Accessibility Guidelines 2.0, W3C World Wide Web Consortium Recommendation
-                        XX Month Year, Level A Success Criteria. (https://www.w3.org/TR/YYYY/REC-WCAG21-YYYYMMDD/)</em></p>
+                  <p><em>Web Content Accessibility Guidelines 2.2, W3C World Wide Web Consortium Recommendation XX Month Year, Level A Success Criteria. (https://www.w3.org/TR/YYYY/REC-WCAG22-YYYYMMDD/)</em></p>
                   			
-                  <p><strong>To cite the Levels A and AA Success Criteria (Double-A conformance):</strong></p>
+                  <p><strong>レベル A 及びレベル AA 達成基準を引用する場合 (レベル AA 適合):</strong></p>
                   			
-                  <p><em>Web Content Accessibility Guidelines 2.0, W3C World Wide Web Consortium Recommendation
-                        XX Month Year, Level A &amp; Level AA Success Criteria. (https://www.w3.org/TR/YYYY/REC-WCAG21-YYYYMMDD/)</em></p>
+                  <p><em>WWeb Content Accessibility Guidelines 2.2, W3C World Wide Web Consortium Recommendation XX Month Year, Level A & Level AA Success Criteria. (https://www.w3.org/TR/YYYY/REC-WCAG22-YYYYMMDD/)</em></p>
                   			
-                  <p><strong>To cite Level A Success Criteria and selected Success Criteria from Level AA and Level
-                        AAA: </strong></p>
+                  <p><strong>レベル A 達成基準及びレベル AA、AAA から選択した達成基準を引用する場合:</strong></p>
                   			
-                  <p><em>Web Content Accessibility Guidelines 2.0, W3C World Wide Web Consortium Recommendation
-                        XX Month Year, Level A Success Criteria plus Success Criteria 1.x.x, 2.y.y, … 3.z.z.
-                        (https://www.w3.org/TR/YYYY/REC-WCAG21-YYYYMMDD/)</em></p>
+                  <p><em>Web Content Accessibility Guidelines 2.2, W3C World Wide Web Consortium Recommendation XX Month Year, Level A Success Criteria plus Success Criteria 1.x.x, 2.y.y, … 3.z.z. (https://www.w3.org/TR/YYYY/REC-WCAG22-YYYYMMDD/)</em></p>
                   			
-                  <p><strong>Example of use of a WCAG reference in a "shall or must" statement.</strong></p>
+                  <p><strong>「必須」要件で WCAG 2.2 を参照する例</strong></p>
                   			
-                  <p>All Web content on publicly available Web sites shall conform to Web Content Accessibility
-                     Guidelines 2.0, W3C World Wide Web Consortium Recommendation XX Month Year, Level
-                     A Success Criteria plus Success Criteria 1.2.3, 2.4.5-6, 3.1.2 (https://www.w3.org/TR/YYYY/REC-WCAG21-YYYYMMDD/)
+                  <p>All Web content on publicly available Web sites shall conform to Web Content Accessibility Guidelines 2.2, W3C World Wide Web Consortium Recommendation XX Month Year, Level A Success Criteria plus Success Criteria 1.2.3, 2.4.5-6, 3.1.2 (https://www.w3.org/TR/YYYY/REC-WCAG22-YYYYMMDD/)
                   </p>
                   		
                </section>
                		
                <section id="conformance-referencing-support">
                   			
-                  <h2>Referring to content from WCAG support documents</h2>
+                  <h2>WCAG 関連文書のコンテンツへの参照</h2>
                   			
-                  <p>Techniques, which are listed in Understanding WCAG 2.1 and described in other supporting
-                     documents, are not part of the normative WCAG 2.1 Recommendation and should not be
-                     cited using the citation for the WCAG 2.1 Recommendation itself. References to techniques
-                     in support documents should be cited separately.
+                  <p>Understanding WCAG 2.2 に挙げられていて、その他の関連文書で説明されている達成方法は、WCAG 2.2 の勧告の一部ではなく、WCAG 2.2 勧告自体の引用を用いて参照すべきではない。関連文書にある達成方法への参照は、別々に行うべきである。
                   </p>
                   			
-                  <p>Techniques can be cited based on the individual Technique document or on the master
-                     WCAG 2.1 Techniques document. For example, the technique "Using alt attributes on
-                     img elements" could be cited as
+                  <p>達成方法は、個々の達成方法文書、又は WCAG 2.2 達成方法の文書の原本をベースに引用することができる。例えば、"Using alt attributes on img elements" という達成方法は、次のように引用することが可能である。
                   </p>
                   			
                   <p class="indented"><em>"Using alt attributes on img elements," W3C World Wide Web Consortium Note. (URI:
@@ -215,10 +180,9 @@
                   			
                   <p class="indented">or</p>
                   			
-                  <p class="indented"><em>W3C World Wide Web Consortium (200x): WCAG2.0 HTML Techniques (URI: {URI of HTML Techniques})</em></p>
+                  <p class="indented"><em>W3C World Wide Web Consortium (20xx): WCAG2.2 HTML Techniques (URI: {URI of HTML Techniques})</em></p>
                   			
-                  <p class="indented"><strong>Techniques are not designed to be referenced as "required"</strong> from any standard or regulation.Standards and regulations should not make any specific
-                     technique mandatory, though they may choose to recommend techniques.
+                  <p class="indented">達成方法は、あらゆる標準規格又は規定から<strong>「必須要件」として参照されることを想定したものではない。</strong>標準規格及び規定は、推奨する達成方法として選ぶことはあっても、いかなる特定の達成方法をも必須とすべきではない。
                   </p>
                   		
                </section>
@@ -233,13 +197,12 @@
                <svg focusable="false" aria-hidden="true" class="icon-comments" viewBox="0 0 28 28">
                   <path d="M22 12c0 4.422-4.922 8-11 8-0.953 0-1.875-0.094-2.75-0.25-1.297 0.922-2.766 1.594-4.344 2-0.422 0.109-0.875 0.187-1.344 0.25h-0.047c-0.234 0-0.453-0.187-0.5-0.453v0c-0.063-0.297 0.141-0.484 0.313-0.688 0.609-0.688 1.297-1.297 1.828-2.594-2.531-1.469-4.156-3.734-4.156-6.266 0-4.422 4.922-8 11-8s11 3.578 11 8zM28 16c0 2.547-1.625 4.797-4.156 6.266 0.531 1.297 1.219 1.906 1.828 2.594 0.172 0.203 0.375 0.391 0.313 0.688v0c-0.063 0.281-0.297 0.484-0.547 0.453-0.469-0.063-0.922-0.141-1.344-0.25-1.578-0.406-3.047-1.078-4.344-2-0.875 0.156-1.797 0.25-2.75 0.25-2.828 0-5.422-0.781-7.375-2.063 0.453 0.031 0.922 0.063 1.375 0.063 3.359 0 6.531-0.969 8.953-2.719 2.609-1.906 4.047-4.484 4.047-7.281 0-0.812-0.125-1.609-0.359-2.375 2.641 1.453 4.359 3.766 4.359 6.375z"></path>
                </svg>
-               <h2> Help improve this page </h2>
+               <h2>このページを改善する</h2>
             </header>
             <div class="box-i">
-               <p>Please share your ideas, suggestions, or comments via e-mail to the publicly-archived
-                  list <a href="mailto:public-agwg-comments@w3.org?subject=%5BUnderstanding%20and%20Techniques%20Feedback%5D">public-agwg-comments@w3.org@w3.org</a> or via GitHub
+               <p>あなたのアイデア、提案、又はコメントを、Google フォーム 又は GitHub で共有してください。
                </p>
-               <div class="button-group"><a href="mailto:public-agwg-comments@w3.org?subject=%5BUnderstanding%20and%20Techniques%20Feedback%5D" class="button"><span>E-mail</span></a><a href="https://github.com/w3c/wcag/issues/" class="button"><span>Fork &amp; Edit on GitHub</span></a><a href="https://github.com/w3c/wcag/issues/new" class="button"><span>New GitHub Issue</span></a></div>
+               <div class="button-group"><a class="button" href="https://waic.jp/contact/" id="file-issue"><span>翻訳に関するお問い合わせ</span></a><a href="https://github.com/waic/wcag22/" class="button"><span>GitHub</span></a></div>
             </div>
          </aside>
       </div>
@@ -254,11 +217,13 @@
                Outreach Working Group (<a href="https://www.w3.org/groups/wg/eowg/participants">EOWG</a>) with contributions from Shadi Abou-Zahra, Steve Lee, and Shawn Lawton Henry as part
                of the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide</a> project, co-funded by the European Commission.
             </p>
+            <p>この文書は、2024 年 2 月 14 日付けの <a href="https://w3c.github.io/wcag/understanding/">Understanding WCAG 2.2</a> を、<a href="https://waic.jp/">ウェブアクセシビリティ基盤委員会 (WAIC)</a> の翻訳ワーキンググループが翻訳して公開しているものです。この文書の正式版は、W3C のサイトにある英語版です。正確な内容については、W3C が公開している原文 (英語) をご確認ください。この翻訳文書は作業進行中です。また、あくまで参考情報であり、翻訳上の誤りが含まれていることがあります。
+            <p>この翻訳文書の利用条件については、<a href="https://waic.jp/license-for-translated-documents/">WAICが提供する翻訳文書のライセンス</a>をご覧ください。</p>
          </div>
       </footer>
       <footer class="site-footer grid-4q" aria-label="Site">
          <div class="q1-start q3-end about">
-            <div>
+            <!--div>
                <p><a class="largelink" href="https://www.w3.org/WAI/" dir="auto" translate="no" lang="en">W3C Web Accessibility Initiative (WAI)</a></p>
                <p>Strategies, standards, and supporting resources to make the Web accessible to people
                   with disabilities.
@@ -280,13 +245,13 @@
                         </svg> YouTube</a></li>
                   <li><a href="https://www.w3.org/WAI/news/subscribe/" class="button">Get News in Email</a></li>
                </ul>
-            </div>
+            </div-->
             <div dir="auto" translate="no" lang="en">
                <p>Copyright © 2024 World Wide Web Consortium (<a href="https://www.w3.org/">W3C</a><sup>®</sup>). See <a href="/WAI/about/using-wai-material/">Permission to Use WAI Material</a>.
                </p>
             </div>
          </div>
-         <div dir="auto" translate="no" class="q4-start q4-end" lang="en">
+         <!--div dir="auto" translate="no" class="q4-start q4-end" lang="en">
             <ul style="margin-bottom:0">
                <li><a href="/WAI/about/contacting/">Contact WAI</a></li>
                <li><a href="/WAI/sitemap/">Site Map</a></li>
@@ -295,7 +260,7 @@
                <li><a href="/WAI/translations/"> Translations</a></li>
                <li><a href="/WAI/roles/">Resources for Roles</a></li>
             </ul>
-         </div>
+         </div-->
       </footer>
       <link rel="stylesheet" href="../a11y-light.css" /><script src="../highlight.min.js"></script><script>
       hljs.configure({
@@ -316,8 +281,10 @@
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
         g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
       })();
-    </script><noscript>
+    </script>
+    <script src="https://waic.jp/docs/js/translation-contact.js"></script>
+      <!--noscript>
          <p><img src="//www.w3.org/analytics/piwik/piwik.php?idsite=328&amp;rec=1" style="border:0;" alt="" /></p>
-      </noscript>
+      </noscript-->
    </body>
 </html>


### PR DESCRIPTION
Close #288

@caztcha 
レビューをお願いします。なお原文の最新版
<https://www.w3.org/WAI/WCAG22/Understanding/refer-to-wcag>
ではWCAG 2.1だったり2.0が正しくWCAG 2.2となっているので、この版で修正しています。