### PR TITLE
H80の翻訳

### DIFF
--- a/techniques/html/H80.html
+++ b/techniques/html/H80.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
-		<title>H80: Identifying the purpose of a link using link text combined with the preceding heading element | WAI | W3C</title>
+<!DOCTYPE html><html lang="ja" xml:lang="ja" xmlns="http://www.w3.org/1999/xhtml"><head>
+		<title>H80: リンクテキストと先行する見出し要素とを組み合わせて、リンクの目的を特定する | WAI | W3C</title>
 		
 	
 
@@ -17,12 +17,12 @@
 <div class="minimal-header-container default-grid">
   <header class="minimal-header" id="site-header">
     <div class="minimal-header-name">
-      <a href="https://w3c.github.io/wcag/techniques/">WCAG 2.2 Techniques</a>
+      <a href="https://waic.jp/translations/WCAG22/Techniques/">WCAG 2.2 テクニック集</a>
     </div>
     
       <div class="minimal-header-subtitle">Examples of ways to meet WCAG; not required</div>
     
-    <a class="minimal-header-link" href="https://w3c.github.io/wcag/techniques/about">About WCAG Techniques</a>
+    <a class="minimal-header-link" href="https://waic.jp/translations/WCAG22/Techniques/about">WCAG テクニック集について</a>
     <div class="minimal-header-logo">
       <a href="http://w3.org/" aria-label="W3C">
         <svg xmlns="http://www.w3.org/2000/svg" height="2em" viewBox="0 0 91.968 44">
@@ -51,14 +51,14 @@
 
 <div class="default-grid with-gap leftcol">
 <aside class="box nav-hack sidebar standalone-resource__sidebar">
-    <header class="box-h">Page Contents</header>
+    <header class="box-h">このページの内容</header>
     <div class="box-i">
       <nav aria-label="page contents" class="navtoc">
-        <ul><li><a href="#technique">About this Technique</a></li>
-<li><a href="#description">Description</a></li>
-<li><a href="#examples">Examples</a></li>
-<li><a href="#related">Related Techniques</a></li>
-<li><a href="#tests">Tests</a></li>
+        <ul><li><a href="#technique">このテクニックについて</a></li>
+<li><a href="#description">解説</a></li>
+<li><a href="#examples">事例</a></li>
+<li><a href="#related">関連テクニック</a></li>
+<li><a href="#tests">検証</a></li>
 </ul>
       </nav>
     </div>
@@ -66,27 +66,27 @@
 
 <main id="main" class="standalone-resource__main">
 		
-<h1><span>Technique H80:</span>Identifying the purpose of a link using link text combined with the preceding heading element</h1>
+<h1><span>テクニック H80:</span>リンクテキストと先行する見出し要素とを組み合わせて、リンクの目的を特定する</h1>
 
 
 
 
 <section id="technique" class="box">
-	<h2 class="box-h box-h-icon">About this Technique</h2>
+	<h2 class="box-h box-h-icon">このテクニックについて</h2>
 	<div class="box-i">
 
 
   
   <p>
-    This technique relates to
+    このテクニックは
     
-<a href="https://w3c.github.io/wcag/understanding/link-purpose-in-context">2.4.4: Link Purpose (In Context)</a>
-(<strong>Advisory</strong>).</p>
+<a href="https://waic.jp/translations/WCAG22/Understanding/link-purpose-in-context">2.4.4: リンクの目的 (コンテキスト内)</a>
+(<strong>参考テクニック</strong>) に関連する。</p>
   
 
 
 
-  <p>This technique applies to <abbr title="HyperText Markup Language">HTML</abbr>.</p>
+  <p>このテクニックは <abbr title="HyperText Markup Language">HTML</abbr> に適用される。</p>
 
 </div>
 </section>
@@ -96,24 +96,26 @@
 		
 		
 		<section id="description">
-			<h2>Description</h2>
-         <p>The objective of this technique is to describe the purpose of a link from the context
-            provided by its heading context. The preceding heading provides context for an otherwise
-            unclear link. The description lets a user distinguish this link from links in the Web
-            page that lead to other destinations and helps the user determine whether to follow the
-            link.</p>
+			<h2>解説</h2>
+         <p>このテクニックの目的は、リンクとその直前にある見出しのコンテキストから、リンクの目的を特定することである。直前にある見出しは、リンクテキストだけでは不明瞭なリンクにコンテキストを提供する。それによって、利用者がそのリンクと、そのウェブページ内にある他のリンクとを区別できるようになり、そのリンク先へ移動するかどうかを判断しやすくなる。</p>
       <div class="note">
-				<p class="note-title marker">Note</p>
+				<p class="note-title marker">注記</p>
 				<div>
-         <p>Whenever possible, provide link text that identifies the purpose of the link without needing additional context.</p>
+         <p>可能なかぎり、コンテキストによる補足を必要とせずにリンクの目的が特定できるリンクテキストを提供すべきである。</p>
+      </div>
+			</div>
+      <div class="note">
+				<p class="note-title marker">訳注</p>
+				<div>
+         <p>WAIC では H80 に関する<a href="https://waic.jp/guideline/as/">アクセシビリティ サポーテッド（AS）情報</a>を提供している。2020 年 3 月版の <a href="https://waic.jp/docs/as/info/techs/H80.html">アクセシビリティ サポーテッド（AS）情報: H80</a> も参照。
       </div>
 			</div>
    </section>
 	 <section id="examples">
-		<h2>Examples</h2>
+		<h2>事例</h2>
 		<section class="example" id="example-1-blocks-of-information-on-hotels">
-			<h3>Example 1: Blocks of information on hotels</h3>
-			<p>The information for each hotel consists of the hotel name, a description and a series of links to a map, photos, directions, guest reviews and a booking form.</p>
+			<h3>事例 1: 複数のホテルに関する情報のブロック</h3>
+			<p>各ホテルの情報は、ホテル名、概要、地図、写真、案内、お客様レビュー、そして予約フォームへのリンクで構成されている。</p>
 
 <pre xml:space="preserve"><code class="language-html">&lt;h2&gt;&lt;a href="royal_palm_hotel.html" id="royal-heading"&gt;Royal Palm Hotel&lt;/a&gt;&lt;/h2&gt;
 &lt;nav aria-labelledby="royal-heading"&gt;
@@ -138,7 +140,7 @@
 &lt;/nav&gt;</code></pre>
       </section>
       <section class="example" id="example-2-a-document-provided-in-three-formats">
-				<h3>Example 2: A document provided in three formats</h3>
+				<h3>事例 2: 三つの形式で提供される文書</h3>
 <pre xml:space="preserve"><code class="language-html">&lt;h2&gt;Annual Report 2006-2007&lt;/h2&gt;
 &lt;p&gt; 
   &lt;a href="annual-report-0607.html"&gt;HTML&lt;/a&gt;
@@ -147,12 +149,12 @@
 &lt;/p&gt;</code></pre>
       </section>
       <section class="example" id="example-3-newspaper-website">
-         <h3>Example 3: Newspaper website</h3>
+         <h3>Example 3: 新聞社のウェブサイト</h3>
 <pre xml:space="preserve"><code class="language-html">&lt;div class="card-link"&gt;
    &lt;h2&gt;&lt;a href="market-2023-09-27.html"&gt;Stock market soars as bullishness prevails&lt;/a&gt;&lt;/h2&gt;
    &lt;p&gt;This week was a stellar week for the stock market as investing in gold rose 2%.&lt;/p&gt;
 &lt;/div&gt;</code></pre>
-         <p>A script is used to find each element with a class of <code>card-link</code> and append an additional paragraph with a "Read more" link at the end of the div with the class <code>.card-link</code> that goes to the same location as the link in the heading.</p>
+         <p>スクリプトを用いて <code>card-link</code> の class の各要素を探し出し、class <code>.card-link</code> を持つ div 要素の末尾に、"Read more" リンクを持つ段落を追加して、見出し内のリンクと同じ所に行くようにしている。</p>
       </section>
    </section>
 	 
@@ -161,7 +163,7 @@
 	
 
 <section id="related">
-		<h2>Related Techniques</h2>
+		<h2>関連テクニック</h2>
 		<ul>
       <li><a href="../general/G91">G91: Providing link text that describes the purpose of a link</a></li>
       <li><a href="../general/G53">G53: Identifying the purpose of a link using link text combined with the text of the enclosing sentence</a></li>
@@ -174,18 +176,18 @@
           the parent list item under which the list is nested</a></li>
    </ul>
 	</section>
-<section id="tests"><h2>Tests</h2>
-      <section class="procedure" id="procedure"><h3>Procedure</h3>
-         <p>For each link in the content that uses this technique:</p>
+<section id="tests"><h2>検証</h2>
+      <section class="procedure" id="procedure"><h3>手順</h3>
+         <p>コンテンツの中で、このテクニックを用いているリンクそれぞれに対して:</p>
          <ol>
-            <li>Find the heading element that precedes the link</li>
-            <li>Check that the text of the link combined with the text of that heading describes the purpose of the link.</li>
+            <li>そのリンクに先行する見出し要素を見つける。</li>
+            <li>そのリンクテキストと見出しを組み合わせると、リンクの目的が説明されていることをチェックする。</li>
          </ol>
       </section>
       <section class="results" id="expected-results">
-				<h3>Expected Results</h3>
+				<h3>期待される結果</h3>
          <ul>
-            <li>#2 is true.</li>
+            <li>2 が真である。</li>
          </ul>
       </section>
    </section>
@@ -205,14 +207,13 @@
     <svg focusable="false" aria-hidden="true" class="icon-comments" viewBox="0 0 28 28">
       <path d="M22 12c0 4.422-4.922 8-11 8-0.953 0-1.875-0.094-2.75-0.25-1.297 0.922-2.766 1.594-4.344 2-0.422 0.109-0.875 0.187-1.344 0.25h-0.047c-0.234 0-0.453-0.187-0.5-0.453v0c-0.063-0.297 0.141-0.484 0.313-0.688 0.609-0.688 1.297-1.297 1.828-2.594-2.531-1.469-4.156-3.734-4.156-6.266 0-4.422 4.922-8 11-8s11 3.578 11 8zM28 16c0 2.547-1.625 4.797-4.156 6.266 0.531 1.297 1.219 1.906 1.828 2.594 0.172 0.203 0.375 0.391 0.313 0.688v0c-0.063 0.281-0.297 0.484-0.547 0.453-0.469-0.063-0.922-0.141-1.344-0.25-1.578-0.406-3.047-1.078-4.344-2-0.875 0.156-1.797 0.25-2.75 0.25-2.828 0-5.422-0.781-7.375-2.063 0.453 0.031 0.922 0.063 1.375 0.063 3.359 0 6.531-0.969 8.953-2.719 2.609-1.906 4.047-4.484 4.047-7.281 0-0.812-0.125-1.609-0.359-2.375 2.641 1.453 4.359 3.766 4.359 6.375z"></path>
     </svg>
-    <h2>Help improve this page</h2>
+    <h2>このページを改善する</h2>
   </header>
   <div class="box-i">
-  <p>Please share your ideas, suggestions, or comments via e-mail to the publicly-archived list <a href="mailto:public-agwg-comments@w3.org?subject=%5BUnderstanding%20and%20Techniques%20Feedback%5D">public-agwg-comments@w3.org</a> or via GitHub</p>
+  <p>あなたのアイデア、提案、又はコメントを、Google フォーム 又は GitHub で共有してください。</p>
     <div class="button-group">
-      <a href="mailto:public-agwg-comments@w3.org?subject=%5BUnderstanding%20and%20Techniques%20Feedback%5D" class="button"><span>E-mail</span></a>
-      <a href="https://github.com/w3c/wcag/issues/" class="button"><span>Fork &amp; Edit on GitHub</span></a>
-      <a href="https://github.com/w3c/wcag/issues/new" class="button"><span>New GitHub Issue</span></a>
+      <a class="button" href="https://docs.google.com/forms/d/e/1FAIpQLSdIpvogLx8kGIMewhQ6MzhG2pOCQZ50iIBViGg8pUrRJuslKg/viewform?entry.685195438=https%3A%2F%2Fwaic.jp%2Ftranslations%2FWCAG22%2FUnderstanding%2Ffocus-not-obscured-minimum" id="file-issue">翻訳に関するお問い合わせ (Google フォーム)</a>
+      <a href="https://github.com/waic/wcag22/" class="button"><span>GitHub</span></a>
     </div>
   </div>
 </aside>
@@ -234,12 +235,15 @@
       <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide</a> project,
       co-funded by the European Commission.
     </p>
+    <p>この文書は、2025 年 5 月 21 日付けの <a href="https://w3c.github.io/wcag/techniques/">Techniques for WCAG 2.2</a> を、<a href="https://waic.jp/">ウェブアクセシビリティ基盤委員会 (WAIC)</a> の翻訳ワーキンググループが翻訳して公開しているものです。この文書の正式版は、W3C のサイトにある英語版です。正確な内容については、W3C が公開している原文 (英語) をご確認ください。この翻訳文書は作業進行中です。また、あくまで参考情報であり、翻訳上の誤りが含まれていることがあります。
+    </p>
+    <p>この翻訳文書の利用条件については、<a href="https://waic.jp/license-for-translated-documents/">WAICが提供する翻訳文書のライセンス</a>をご覧ください。</p>
   </div>
 </footer>
 
 <footer class="site-footer grid-4q" aria-label="Site">
   <div class="q1-start q3-end about">
-    <div>
+    <!--div>
       <p><a class="largelink" href="https://www.w3.org/WAI/" dir="auto" translate="no" lang="en">W3C Web Accessibility Initiative (WAI)</a></p>
       <p>Strategies, standards, and supporting resources to make the Web accessible to people with disabilities.</p>
     </div>
@@ -250,12 +254,12 @@
         <li><a href="https://www.youtube.com/channel/UCU6ljj3m1fglIPjSjs2DpRA/playlistsv"><svg focusable="false" aria-hidden="true" class="icon-youtube " viewBox="0 0 32 32"><path d="M31.327 8.273c-0.386-1.353-1.431-2.398-2.756-2.777l-0.028-0.007c-2.493-0.668-12.528-0.668-12.528-0.668s-10.009-0.013-12.528 0.668c-1.353 0.386-2.398 1.431-2.777 2.756l-0.007 0.028c-0.443 2.281-0.696 4.903-0.696 7.585 0 0.054 0 0.109 0 0.163l-0-0.008c-0 0.037-0 0.082-0 0.126 0 2.682 0.253 5.304 0.737 7.845l-0.041-0.26c0.386 1.353 1.431 2.398 2.756 2.777l0.028 0.007c2.491 0.669 12.528 0.669 12.528 0.669s10.008 0 12.528-0.669c1.353-0.386 2.398-1.431 2.777-2.756l0.007-0.028c0.425-2.233 0.668-4.803 0.668-7.429 0-0.099-0-0.198-0.001-0.297l0 0.015c0.001-0.092 0.001-0.201 0.001-0.31 0-2.626-0.243-5.196-0.708-7.687l0.040 0.258zM12.812 20.801v-9.591l8.352 4.803z"></path></svg> YouTube</a></li>
         <li><a href="https://www.w3.org/WAI/news/subscribe/" class="button">Get News in Email</a></li>
       </ul>
-    </div>
+    </div-->
     <div dir="auto" translate="no" lang="en">
       <p>Copyright © 2025 World Wide Web Consortium (<a href="https://www.w3.org/">W3C</a><sup>®</sup>). See <a href="/WAI/about/using-wai-material/">Permission to Use WAI Material</a>.</p>
     </div>
   </div>
-  <div dir="auto" translate="no" class="q4-start q4-end" lang="en">
+  <!--div dir="auto" translate="no" class="q4-start q4-end" lang="en">
     <ul style="margin-bottom:0">
       <li><a href="/WAI/about/contacting/">Contact WAI</a></li>
       <li><a href="/WAI/sitemap/">Site Map</a></li>
@@ -264,7 +268,7 @@
       <li><a href="/WAI/translations/"> Translations</a></li>
       <li><a href="/WAI/roles/">Resources for Roles</a></li>
     </ul>
-  </div>
+  </div-->
 </footer>
 
 <link rel="stylesheet" href="../a11y-light.css">
@@ -278,7 +282,7 @@
 </script>
 <script src="https://www.w3.org/WAI/assets/scripts/main.js"></script>
 
-<script>
+<!--script>
   var _paq = _paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
   _paq.push(["setDoNotTrack", true]);
@@ -294,7 +298,7 @@
 </script>
 <noscript>
   <p><img src="//www.w3.org/analytics/piwik/piwik.php?idsite=328&amp;rec=1" style="border:0;" alt="" /></p>
-</noscript>
-
+</noscript-->
+<script src="https://waic.jp/docs/js/translation-contact.js"></script>
 
 </body></html>


### PR DESCRIPTION
Close https://github.com/waic/wcag22/issues/902

H80の翻訳です。

raw.githack.com
https://raw.githack.com/waic/wcag22/momdo-H80/techniques/html/H80.html

@caztcha
レビューをお願いします。

原文の差分はないため、最低限の修正になります。
訳注のAS情報は、2020年版のみ追記しています（さすがに古い方はもうよいでしょう…）