### PR TITLE
H76の翻訳

### DIFF
--- a/techniques/html/H76.html
+++ b/techniques/html/H76.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
-      <title>H76: Using meta refresh to create an instant client-side redirect | WAI | W3C</title>
+<!DOCTYPE html><html lang="ja" xml:lang="ja" xmlns="http://www.w3.org/1999/xhtml"><head>
+      <title>H76: クライアントサイドで即時にリダイレクトするために、meta 要素の refresh を使用する | WAI | W3C</title>
       
    
 
@@ -17,12 +17,12 @@
 <div class="minimal-header-container default-grid">
   <header class="minimal-header" id="site-header">
     <div class="minimal-header-name">
-      <a href="https://w3c.github.io/wcag/techniques/">WCAG 2.2 Techniques</a>
+      <a href="https://waic.jp/translations/WCAG22/Techniques/">WCAG 2.2 テクニック集</a>
     </div>
     
       <div class="minimal-header-subtitle">Examples of ways to meet WCAG; not required</div>
     
-    <a class="minimal-header-link" href="https://w3c.github.io/wcag/techniques/about">About WCAG Techniques</a>
+    <a class="minimal-header-link" href="https://waic.jp/translations/WCAG22/Techniques/about">WCAG テクニック集について</a>
     <div class="minimal-header-logo">
       <a href="http://w3.org/" aria-label="W3C">
         <svg xmlns="http://www.w3.org/2000/svg" height="2em" viewBox="0 0 91.968 44">
@@ -51,16 +51,16 @@
 
 <div class="default-grid with-gap leftcol">
 <aside class="box nav-hack sidebar standalone-resource__sidebar">
-    <header class="box-h">Page Contents</header>
+    <header class="box-h">このページの内容</header>
     <div class="box-i">
       <nav aria-label="page contents" class="navtoc">
-        <ul><li><a href="#technique">About this Technique</a></li>
-<li><a href="#description">Description</a></li>
-<li><a href="#examples">Examples</a></li>
-<li><a href="#resources">Related Resources</a></li>
-<li><a href="#related">Related Techniques</a></li>
-<li><a href="#tests">Tests</a></li>
-<li><a href="#test-rules">Test Rules</a></li>
+        <ul><li><a href="#technique">このテクニックについて</a></li>
+<li><a href="#description">解説</a></li>
+<li><a href="#examples">事例</a></li>
+<li><a href="#resources">関連リソース</a></li>
+<li><a href="#related">関連テクニック</a></li>
+<li><a href="#tests">検証</a></li>
+<li><a href="#test-rules">テストルール</a></li>
 </ul>
       </nav>
     </div>
@@ -68,28 +68,25 @@
 
 <main id="main" class="standalone-resource__main">
       
-<h1><span>Technique H76:</span>Using <code class="language-html">meta</code> <code class="language-html">refresh</code> to create an instant client-side redirect</h1>
+<h1><span>テクニック H76:</span>クライアントサイドで即時にリダイレクトするために、<code class="language-html">meta</code> 要素の <code class="language-html">refresh</code> を使用する</h1>
 
 
 
 
 <section id="technique" class="box">
-	<h2 class="box-h box-h-icon">About this Technique</h2>
+	<h2 class="box-h box-h-icon">このテクニックについて</h2>
 	<div class="box-i">
 
 
   
   <p>
-    This technique relates to
-    
-<a href="https://w3c.github.io/wcag/understanding/change-on-request">3.2.5: Change on Request</a>
-(<strong>Sufficient</strong>
-  when used with <a href="../general/G110">G110: Using an instant client-side redirect</a>).</p>
+    このテクニックは、<a href="https://waic.jp/translations/WCAG22/Understanding/change-on-request">3.2.5: 要求による変化</a>
+(<a href="../general/G110">G110: Using an instant client-side redirect</a> と併用する場合に<strong>十分なテクニック</strong>) に関連する。</p>
   
 
 
 
-  <p>This technique applies to <abbr title="HyperText Markup Language">HTML</abbr>.</p>
+  <p>このテクニックは、<abbr title="HyperText Markup Language">HTML</abbr> に適用される。</p>
 
 </div>
 </section>
@@ -99,14 +96,14 @@
       
       
       <section id="description">
-         <h2>Description</h2>
-         <p>The objective of this technique is to enable redirects on the client side without confusing the user. Redirects are preferably implemented on the server side (see <a href="../server-side-script/SVR1">Implementing automatic redirects on the server side instead of on the client side</a>), but authors do not always have control over server-side technologies.</p>
-         <p>In HTML, one can use the <code class="language-html">meta</code> element with the value of the <code class="language-html">http-equiv</code> attribute set to <code class="language-html">refresh</code> and the value of the <code class="language-html">content</code> attribute set to <code class="language-html">0</code> (meaning zero seconds), followed by the <abbr title="Uniform Resource Identifier">URI</abbr> that the browser should request. It is important that the time-out is set to zero, to avoid that content is displayed before the new page is loaded. The page containing the redirect code should only contain information related to the redirect.</p>
+         <h2>解説</h2>
+         <p>このテクニックの目的は、クライアントサイドで利用可能なリダイレクトを、利用者を混乱させることなく用いることである。リダイレクトはサーバーサイドで実装するほうが望ましいが (<a href="../server-side-script/SVR1">Implementing automatic redirects on the server side instead of on the client side</a> を参照)、コンテンツ制作者がサーバーサイド技術を管理しているとは限らない。</p>
+         <p>HTML では、<code class="language-html">meta</code> 要素に <code class="language-html">http-equiv</code> 属性には <code class="language-html">refresh</code> という値、<code class="language-html">content</code> 属性の値には <code class="language-html">0</code> (ゼロ秒を意味する) を、ブラウザが要求すべき <abbr title="Uniform Resource Identifier">URI</abbr> を後に伴って指定することができる。重要なのは、新たなページを読み込む前にコンテンツが表示されるのを避けるために、タイムアウトをゼロに設定することである。リダイレクトのコードを指定したページには、リダイレクトに関する情報のみを含めるべきである。</p>
       </section>
       <section id="examples">
-         <h2>Examples</h2>
+         <h2>事例</h2>
          <section class="example" id="example-1-instantly-redirecting-a-page">
-            <h3>Example 1: Instantly redirecting a page</h3>
+            <h3>事例 1: 即時にページをリダイレクトする</h3>
 <pre xml:space="preserve"><code class="language-html">&lt;!doctype html&gt;
 &lt;html lang="en"&gt;    
   &lt;head&gt;
@@ -124,8 +121,8 @@
       
    
    <section id="resources">
-      <h2>Related Resources</h2>
-<p style="margin-bottom: 1.5em;"><em><small>No endorsement implied.</small></em></p>
+			<h2>関連リソース</h2>
+<p style="margin-bottom: 1.5em;"><em><small>推奨を意味するものではない。</small></em></p>
 
 
       <ul>
@@ -136,39 +133,36 @@
 
 
 <section id="related">
-      <h2>Related Techniques</h2>
+			<h2>関連テクニック</h2>
       <ul>
          <li><a href="../general/G110">G110: Using an instant client-side redirect</a></li>
       </ul>
    </section>
 <section id="tests">
-         <h2>Tests</h2>
+         <h2>検証</h2>
          <section class="procedure" id="procedure">
-            <h3>Procedure</h3>
-            <p>Find all <code class="language-html">meta</code> elements in the document that contain the <code class="language-html">http-equiv</code> attribute with value <code class="language-html">refresh</code>, check that:</p>
+            <h3>手順</h3>
+            <p>ドキュメント内で、値が <code class="language-html">refresh</code> に設定された <code class="language-html">http-equiv</code> 属性を含む全ての <code class="language-html">meta</code> 要素を検索し、次の点をチェックする:</p>
             <ol>
-               <li>the <code class="language-html">content</code> attribute has a number with a value of <code class="language-html">0</code>, and</li>
-               <li>the number is followed by <code class="language-html">;URL=anyURL</code> (where anyURL stands for the URI that should replace the current page).</li>
+               <li><code class="language-html">content</code> 属性に値が <code class="language-html">0</code> の数値を持っている</li>
+               <li>その数値の後に <code class="language-html">;URL=anyURL</code> が続いている (anyURL は現在のページを置き換える URI を表す)</li>
             </ol>
          </section>
          <section class="results" id="expected-results">
-            <h3>Expected Results</h3>
-            <p>Steps #1 and #2 are true.</p>
+				<h3>期待される結果</h3>
+            <p>ステップ 1 及び 2 が真である。</p>
       </section>
    </section>
 <section id="test-rules">
-  <h2>Test Rules</h2>
+  <h2>テストルール</h2>
   <p>
-    The following are Test Rules
-    related to this Technique.
-    It is not necessary to use these particular Test Rules to check for conformance with WCAG, but they are defined and approved test methods.
-    For information on using Test Rules, see <a href="https://w3c.github.io/wcag/understanding/understanding-act-rules.html">Understanding Test Rules for WCAG Success Criteria</a>.
+    次は、この達成基準の特定の側面に関するテストルールである。この特定のルールを使用して WCAG に適合しているかどうかを確認する必要はないが、これらのルールは定義され、承認されたテスト方法である。テストルールの使用については、<a href="https://waic.jp/translations/WCAG22/Understanding/understanding-act-rules.html">WCAG 達成基準のテストルールを理解する</a>を参照。
   </p>
   <ul>
   
-    <li><a href="/WAI/standards-guidelines/act/rules/bc659a/">Meta element has no refresh delay</a></li>
+    <li><a href="https://www.w3.org/WAI/standards-guidelines/act/rules/bc659a/">Meta element has no refresh delay</a></li>
   
-    <li><a href="/WAI/standards-guidelines/act/rules/bisz58/">Meta element has no refresh delay (no exception)</a></li>
+    <li><a href="https://www.w3.org/WAI/standards-guidelines/act/rules/bisz58/">Meta element has no refresh delay (no exception)</a></li>
   
   </ul>
 </section>
@@ -187,14 +181,13 @@
     <svg focusable="false" aria-hidden="true" class="icon-comments" viewBox="0 0 28 28">
       <path d="M22 12c0 4.422-4.922 8-11 8-0.953 0-1.875-0.094-2.75-0.25-1.297 0.922-2.766 1.594-4.344 2-0.422 0.109-0.875 0.187-1.344 0.25h-0.047c-0.234 0-0.453-0.187-0.5-0.453v0c-0.063-0.297 0.141-0.484 0.313-0.688 0.609-0.688 1.297-1.297 1.828-2.594-2.531-1.469-4.156-3.734-4.156-6.266 0-4.422 4.922-8 11-8s11 3.578 11 8zM28 16c0 2.547-1.625 4.797-4.156 6.266 0.531 1.297 1.219 1.906 1.828 2.594 0.172 0.203 0.375 0.391 0.313 0.688v0c-0.063 0.281-0.297 0.484-0.547 0.453-0.469-0.063-0.922-0.141-1.344-0.25-1.578-0.406-3.047-1.078-4.344-2-0.875 0.156-1.797 0.25-2.75 0.25-2.828 0-5.422-0.781-7.375-2.063 0.453 0.031 0.922 0.063 1.375 0.063 3.359 0 6.531-0.969 8.953-2.719 2.609-1.906 4.047-4.484 4.047-7.281 0-0.812-0.125-1.609-0.359-2.375 2.641 1.453 4.359 3.766 4.359 6.375z"></path>
     </svg>
-    <h2>Help improve this page</h2>
+    <h2>このページを改善する</h2>
   </header>
   <div class="box-i">
-  <p>Please share your ideas, suggestions, or comments via e-mail to the publicly-archived list <a href="mailto:public-agwg-comments@w3.org?subject=%5BUnderstanding%20and%20Techniques%20Feedback%5D">public-agwg-comments@w3.org</a> or via GitHub</p>
+  <p>あなたのアイデア、提案、又はコメントを、Google フォーム 又は GitHub で共有してください。</p>
     <div class="button-group">
-      <a href="mailto:public-agwg-comments@w3.org?subject=%5BUnderstanding%20and%20Techniques%20Feedback%5D" class="button"><span>E-mail</span></a>
-      <a href="https://github.com/w3c/wcag/issues/" class="button"><span>Fork &amp; Edit on GitHub</span></a>
-      <a href="https://github.com/w3c/wcag/issues/new" class="button"><span>New GitHub Issue</span></a>
+      <a class="button" href="https://docs.google.com/forms/d/e/1FAIpQLSdIpvogLx8kGIMewhQ6MzhG2pOCQZ50iIBViGg8pUrRJuslKg/viewform?entry.685195438=https%3A%2F%2Fwaic.jp%2Ftranslations%2FWCAG22%2FUnderstanding%2Ffocus-not-obscured-minimum" id="file-issue">翻訳に関するお問い合わせ (Google フォーム)</a>
+      <a href="https://github.com/waic/wcag22/" class="button"><span>GitHub</span></a>
     </div>
   </div>
 </aside>
@@ -216,12 +209,15 @@
       <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide</a> project,
       co-funded by the European Commission.
     </p>
+    <p>この文書は、2025 年 5 月 21 日付けの <a href="https://w3c.github.io/wcag/techniques/">Techniques for WCAG 2.2</a> を、<a href="https://waic.jp/">ウェブアクセシビリティ基盤委員会 (WAIC)</a> の翻訳ワーキンググループが翻訳して公開しているものです。この文書の正式版は、W3C のサイトにある英語版です。正確な内容については、W3C が公開している原文 (英語) をご確認ください。この翻訳文書は作業進行中です。また、あくまで参考情報であり、翻訳上の誤りが含まれていることがあります。
+    </p>
+    <p>この翻訳文書の利用条件については、<a href="https://waic.jp/license-for-translated-documents/">WAICが提供する翻訳文書のライセンス</a>をご覧ください。</p>
   </div>
 </footer>
 
 <footer class="site-footer grid-4q" aria-label="Site">
   <div class="q1-start q3-end about">
-    <div>
+    <!--div>
       <p><a class="largelink" href="https://www.w3.org/WAI/" dir="auto" translate="no" lang="en">W3C Web Accessibility Initiative (WAI)</a></p>
       <p>Strategies, standards, and supporting resources to make the Web accessible to people with disabilities.</p>
     </div>
@@ -232,12 +228,12 @@
         <li><a href="https://www.youtube.com/channel/UCU6ljj3m1fglIPjSjs2DpRA/playlistsv"><svg focusable="false" aria-hidden="true" class="icon-youtube " viewBox="0 0 32 32"><path d="M31.327 8.273c-0.386-1.353-1.431-2.398-2.756-2.777l-0.028-0.007c-2.493-0.668-12.528-0.668-12.528-0.668s-10.009-0.013-12.528 0.668c-1.353 0.386-2.398 1.431-2.777 2.756l-0.007 0.028c-0.443 2.281-0.696 4.903-0.696 7.585 0 0.054 0 0.109 0 0.163l-0-0.008c-0 0.037-0 0.082-0 0.126 0 2.682 0.253 5.304 0.737 7.845l-0.041-0.26c0.386 1.353 1.431 2.398 2.756 2.777l0.028 0.007c2.491 0.669 12.528 0.669 12.528 0.669s10.008 0 12.528-0.669c1.353-0.386 2.398-1.431 2.777-2.756l0.007-0.028c0.425-2.233 0.668-4.803 0.668-7.429 0-0.099-0-0.198-0.001-0.297l0 0.015c0.001-0.092 0.001-0.201 0.001-0.31 0-2.626-0.243-5.196-0.708-7.687l0.040 0.258zM12.812 20.801v-9.591l8.352 4.803z"></path></svg> YouTube</a></li>
         <li><a href="https://www.w3.org/WAI/news/subscribe/" class="button">Get News in Email</a></li>
       </ul>
-    </div>
+    </div-->
     <div dir="auto" translate="no" lang="en">
       <p>Copyright © 2025 World Wide Web Consortium (<a href="https://www.w3.org/">W3C</a><sup>®</sup>). See <a href="/WAI/about/using-wai-material/">Permission to Use WAI Material</a>.</p>
     </div>
   </div>
-  <div dir="auto" translate="no" class="q4-start q4-end" lang="en">
+  <!--div dir="auto" translate="no" class="q4-start q4-end" lang="en">
     <ul style="margin-bottom:0">
       <li><a href="/WAI/about/contacting/">Contact WAI</a></li>
       <li><a href="/WAI/sitemap/">Site Map</a></li>
@@ -246,7 +242,7 @@
       <li><a href="/WAI/translations/"> Translations</a></li>
       <li><a href="/WAI/roles/">Resources for Roles</a></li>
     </ul>
-  </div>
+  </div-->
 </footer>
 
 <link rel="stylesheet" href="../a11y-light.css">
@@ -260,7 +256,7 @@
 </script>
 <script src="https://www.w3.org/WAI/assets/scripts/main.js"></script>
 
-<script>
+<!--script>
   var _paq = _paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
   _paq.push(["setDoNotTrack", true]);
@@ -276,7 +272,7 @@
 </script>
 <noscript>
   <p><img src="//www.w3.org/analytics/piwik/piwik.php?idsite=328&amp;rec=1" style="border:0;" alt="" /></p>
-</noscript>
-
+</noscript-->
+<script src="https://waic.jp/docs/js/translation-contact.js"></script>
 
 </body></html>


### PR DESCRIPTION
Close https://github.com/waic/wcag22/issues/905

H76の翻訳です。

raw.githack.com
https://raw.githack.com/waic/wcag22/momdo-H76/techniques/html/H76.html

@caztcha
レビューをお願いします。

タイトルについて、instantを「瞬間的に」としていましたが、「即時に」の方が適切では？ということで修正しています。

そのほかは基本的に転記しています。