### PR TITLE
H64の翻訳

### DIFF
--- a/techniques/html/H64.html
+++ b/techniques/html/H64.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
-      <title>H64: Using the title attribute of the iframe element | WAI | W3C</title>
+<!DOCTYPE html><html lang="ja" xml:lang="ja" xmlns="http://www.w3.org/1999/xhtml"><head>
+      <title>H64: iframe 要素の title 属性を使用する | WAI | W3C</title>
       
    
 
@@ -17,12 +17,12 @@
 <div class="minimal-header-container default-grid">
   <header class="minimal-header" id="site-header">
     <div class="minimal-header-name">
-      <a href="https://w3c.github.io/wcag/techniques/">WCAG 2.2 Techniques</a>
+      <a href="https://waic.jp/translations/WCAG22/Techniques/">WCAG 2.2 テクニック集</a>
     </div>
     
       <div class="minimal-header-subtitle">Examples of ways to meet WCAG; not required</div>
     
-    <a class="minimal-header-link" href="https://w3c.github.io/wcag/techniques/about">About WCAG Techniques</a>
+    <a class="minimal-header-link" href="https://waic.jp/translations/WCAG22/Techniques/about">WCAG テクニック集について</a>
     <div class="minimal-header-logo">
       <a href="http://w3.org/" aria-label="W3C">
         <svg xmlns="http://www.w3.org/2000/svg" height="2em" viewBox="0 0 91.968 44">
@@ -51,14 +51,14 @@
 
 <div class="default-grid with-gap leftcol">
 <aside class="box nav-hack sidebar standalone-resource__sidebar">
-    <header class="box-h">Page Contents</header>
+    <header class="box-h">このページの内容</header>
     <div class="box-i">
       <nav aria-label="page contents" class="navtoc">
-        <ul><li><a href="#technique">About this Technique</a></li>
-<li><a href="#description">Description</a></li>
-<li><a href="#examples">Examples</a></li>
-<li><a href="#resources">Related Resources</a></li>
-<li><a href="#tests">Tests</a></li>
+        <ul><li><a href="#technique">このテクニックについて</a></li>
+<li><a href="#description">解説</a></li>
+<li><a href="#examples">事例</a></li>
+<li><a href="#resources">関連リソース</a></li>
+<li><a href="#tests">検証</a></li>
 </ul>
       </nav>
     </div>
@@ -66,32 +66,30 @@
 
 <main id="main" class="standalone-resource__main">
       
-<h1><span>Technique H64:</span>Using the <code class="language-html">title</code> attribute of the <code class="language-html">iframe</code> element</h1>
+<h1><span>テクニック H64:</span><code class="language-html">iframe</code> 要素の <code class="language-html">title</code> 属性を使用する</h1>
 
 
 
 
 <section id="technique" class="box">
-	<h2 class="box-h box-h-icon">About this Technique</h2>
+	<h2 class="box-h box-h-icon">このテクニックについて</h2>
 	<div class="box-i">
 
 
   
-  <p>This technique relates to:</p>
+  <p>このテクニックは、次に関連する:</p>
   <ul>
   
     <li>
       
-<a href="https://w3c.github.io/wcag/understanding/bypass-blocks">2.4.1: Bypass Blocks</a>
-(<strong>Sufficient</strong>
-  when used for grouping blocks of repeated material in a way that can be skipped)
+<a href="https://waic.jp/translations/WCAG22/Understanding/bypass-blocks">2.4.1: ブロックスキップ</a>
+(スキップ可能な方法で繰り返しの情報のブロックをグループ化するために使用される場合に<strong>十分なテクニック</strong>)
     </li>
   
     <li>
       
-<a href="https://w3c.github.io/wcag/understanding/name-role-value">4.1.2: Name, Role, Value</a>
-(<strong>Sufficient</strong>
-  when used with <a href="../general/G108">G108: Using markup features to expose the name and role, allow user-settable properties to be directly set, and provide notification of changes</a>)
+<a href="https://waic.jp/translations/WCAG22/Understanding/name-role-value">4.1.2: 名前 (name)・役割 (role)・値 (value)</a>
+(<a href="../general/G108">G108: Using markup features to expose the name and role, allow user-settable properties to be directly set, and provide notification of changes</a>と併用する場合に<strong>十分なテクニック</strong>)
     </li>
   
   </ul>
@@ -99,7 +97,7 @@
 
 
 
-  <p>This technique applies to <abbr title="HyperText Markup Language">HTML</abbr> documents that use <code class="language-html">iframe</code>s.</p>
+  <p>このテクニックは、<code class="language-html">iframe</code> を使用する <abbr title="HyperText Markup Language">HTML</abbr> ドキュメントに適用される。</p>
 
 </div>
 </section>
@@ -109,20 +107,20 @@
       
       
       <section id="description">
-        <h2>Description</h2>
-        <p>The objective of this technique is to demonstrate the use of the <code class="language-html">title</code> attribute of the <code class="language-html">iframe</code> element to describe its contents. This provides a label for the frame so users can determine which frame to enter and explore in detail. It does not label the content inside the <code class="language-html">iframe</code>.</p>
+        <h2>解説</h2>
+        <p>このテクニックは、<code class="language-html">iframe</code> 要素の <code class="language-html">title</code> 属性を用いてそのコンテンツを説明する方法を示すものである。この属性はフレームにラベルを付けることで、ユーザーがどのフレームに入り、詳細を閲覧するかを判断できるようにする。<code class="language-html">iframe</code> 内のコンテンツ自体にラベルを付けるわけではない。</p>
         <div class="note">
-				<p class="note-title marker">Note</p>
+				<p class="note-title marker">注記</p>
 				<div>
-          <p>The <code class="language-html">title</code> attribute labels <code class="language-html">iframe</code>s, and is different from the <code class="language-html">title</code> element which labels documents. Both should be provided, since the first facilitates navigation among <code class="language-html">iframe</code>s and the second clarifies the user's current page.</p>
+          <p><code class="language-html">title</code> 属性は <code class="language-html">iframe</code> にラベルを付けるものであり、文書にラベルを付ける <code class="language-html">title</code> 要素とは異なる。前者は <code class="language-html">iframe</code> 間のナビゲーションを容易にし、後者は利用者が現在閲覧しているページを明確にするものであるため、両方とも提供する必要がある。</p>
         </div>
 			</div>
-        <p>The <code class="language-html">title</code> attribute is not interchangeable with the <code class="language-html">name</code> attribute. The <code class="language-html">title</code> labels the frame for users; the <code class="language-html">name</code> labels it for scripting and window targeting. The <code class="language-html">name</code> is not presented to the user, only the <code class="language-html">title</code> is.</p>
+        <p><code class="language-html">title</code> 属性は <code class="language-html">name</code> 属性と互換性はない。<code class="language-html">title</code> 属性は利用者にとってフレームのラベルとなり、<code class="language-html">name</code> 属性はスクリプト及びウィンドウのターゲット設定においてフレームのラベルとなる。<code class="language-html">name</code> 属性は利用者には表示されず、<code class="language-html">title</code> のみが提供される。</p>
    </section>
    <section id="examples">
-		<h2>Examples</h2>
+		<h2>事例</h2>
     <section class="example" id="example-1-using-the-title-attribute-with-an-iframe-to-describe-the-iframe's-content">
-    	<h3>Example 1: Using the <code class="language-html">title</code> attribute with an <code class="language-html">iframe</code> to describe the <code class="language-html">iframe</code>'s content</h3>
+    	<h3>事例 1: <code class="language-html">iframe</code> のコンテンツを説明するために、<code class="language-html">iframe</code> で <code class="language-html">title</code> 属性を使用する</h3>
 
 <pre xml:space="preserve"><code class="language-html">&lt;!doctype html&gt;
 &lt;html lang="en"&gt;
@@ -137,8 +135,8 @@
    </section>
    
    <section id="resources">
-		<h2>Related Resources</h2>
-<p style="margin-bottom: 1.5em;"><em><small>No endorsement implied.</small></em></p>
+		<h2>関連リソース</h2>
+<p style="margin-bottom: 1.5em;"><em><small>推奨を意味するものではない。</small></em></p>
 
 
 		<ul>
@@ -151,18 +149,18 @@
 
 
 <section id="tests">
-      <h2>Tests</h2>
+      <h2>検証</h2>
       <section class="procedure" id="procedure">
-         <h3>Procedure</h3>
+         <h3>手順</h3>
          <ol>
-            <li>Check each <code class="language-html">iframe</code> element in the HTML source code for the presence of a <code class="language-html">title</code> attribute.</li>
-            <li>Check that the <code class="language-html">title</code> attribute contains text that describes the <code class="language-html">iframe</code>'s content.</li>
+            <li>HTML ソースコード内の各 <code class="language-html">iframe</code> 要素に <code class="language-html">title</code> 属性が存在するかどうかをチェックする。</li>
+            <li>その<code class="language-html">title</code> 属性に その<code class="language-html">iframe</code> のコンテンツを説明するテキストが含まれていることをチェックする。</li>
          </ol>
       </section>
       <section class="results" id="expected-results">
-         <h3>Expected Results</h3>
+         <h3>期待される結果</h3>
          <ul>
-            <li>Checks #1 and #2 are true.</li>
+            <li>チェック 1 及び 2 が真である。</li>
          </ul>
       </section>
    </section>
@@ -182,14 +180,13 @@
     <svg focusable="false" aria-hidden="true" class="icon-comments" viewBox="0 0 28 28">
       <path d="M22 12c0 4.422-4.922 8-11 8-0.953 0-1.875-0.094-2.75-0.25-1.297 0.922-2.766 1.594-4.344 2-0.422 0.109-0.875 0.187-1.344 0.25h-0.047c-0.234 0-0.453-0.187-0.5-0.453v0c-0.063-0.297 0.141-0.484 0.313-0.688 0.609-0.688 1.297-1.297 1.828-2.594-2.531-1.469-4.156-3.734-4.156-6.266 0-4.422 4.922-8 11-8s11 3.578 11 8zM28 16c0 2.547-1.625 4.797-4.156 6.266 0.531 1.297 1.219 1.906 1.828 2.594 0.172 0.203 0.375 0.391 0.313 0.688v0c-0.063 0.281-0.297 0.484-0.547 0.453-0.469-0.063-0.922-0.141-1.344-0.25-1.578-0.406-3.047-1.078-4.344-2-0.875 0.156-1.797 0.25-2.75 0.25-2.828 0-5.422-0.781-7.375-2.063 0.453 0.031 0.922 0.063 1.375 0.063 3.359 0 6.531-0.969 8.953-2.719 2.609-1.906 4.047-4.484 4.047-7.281 0-0.812-0.125-1.609-0.359-2.375 2.641 1.453 4.359 3.766 4.359 6.375z"></path>
     </svg>
-    <h2>Help improve this page</h2>
+    <h2>このページを改善する</h2>
   </header>
   <div class="box-i">
-  <p>Please share your ideas, suggestions, or comments via e-mail to the publicly-archived list <a href="mailto:public-agwg-comments@w3.org?subject=%5BUnderstanding%20and%20Techniques%20Feedback%5D">public-agwg-comments@w3.org</a> or via GitHub</p>
+  <p>あなたのアイデア、提案、又はコメントを、Google フォーム 又は GitHub で共有してください。</p>
     <div class="button-group">
-      <a href="mailto:public-agwg-comments@w3.org?subject=%5BUnderstanding%20and%20Techniques%20Feedback%5D" class="button"><span>E-mail</span></a>
-      <a href="https://github.com/w3c/wcag/issues/" class="button"><span>Fork &amp; Edit on GitHub</span></a>
-      <a href="https://github.com/w3c/wcag/issues/new" class="button"><span>New GitHub Issue</span></a>
+      <a class="button" href="https://docs.google.com/forms/d/e/1FAIpQLSdIpvogLx8kGIMewhQ6MzhG2pOCQZ50iIBViGg8pUrRJuslKg/viewform?entry.685195438=https%3A%2F%2Fwaic.jp%2Ftranslations%2FWCAG22%2FUnderstanding%2Ffocus-not-obscured-minimum" id="file-issue">翻訳に関するお問い合わせ (Google フォーム)</a>
+      <a href="https://github.com/waic/wcag22/" class="button"><span>GitHub</span></a>
     </div>
   </div>
 </aside>
@@ -211,12 +208,15 @@
       <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide</a> project,
       co-funded by the European Commission.
     </p>
+    <p>この文書は、2025 年 5 月 21 日付けの <a href="https://w3c.github.io/wcag/techniques/">Techniques for WCAG 2.2</a> を、<a href="https://waic.jp/">ウェブアクセシビリティ基盤委員会 (WAIC)</a> の翻訳ワーキンググループが翻訳して公開しているものです。この文書の正式版は、W3C のサイトにある英語版です。正確な内容については、W3C が公開している原文 (英語) をご確認ください。この翻訳文書は作業進行中です。また、あくまで参考情報であり、翻訳上の誤りが含まれていることがあります。
+    </p>
+    <p>この翻訳文書の利用条件については、<a href="https://waic.jp/license-for-translated-documents/">WAICが提供する翻訳文書のライセンス</a>をご覧ください。</p>
   </div>
 </footer>
 
 <footer class="site-footer grid-4q" aria-label="Site">
   <div class="q1-start q3-end about">
-    <div>
+    <!--div>
       <p><a class="largelink" href="https://www.w3.org/WAI/" dir="auto" translate="no" lang="en">W3C Web Accessibility Initiative (WAI)</a></p>
       <p>Strategies, standards, and supporting resources to make the Web accessible to people with disabilities.</p>
     </div>
@@ -227,12 +227,12 @@
         <li><a href="https://www.youtube.com/channel/UCU6ljj3m1fglIPjSjs2DpRA/playlistsv"><svg focusable="false" aria-hidden="true" class="icon-youtube " viewBox="0 0 32 32"><path d="M31.327 8.273c-0.386-1.353-1.431-2.398-2.756-2.777l-0.028-0.007c-2.493-0.668-12.528-0.668-12.528-0.668s-10.009-0.013-12.528 0.668c-1.353 0.386-2.398 1.431-2.777 2.756l-0.007 0.028c-0.443 2.281-0.696 4.903-0.696 7.585 0 0.054 0 0.109 0 0.163l-0-0.008c-0 0.037-0 0.082-0 0.126 0 2.682 0.253 5.304 0.737 7.845l-0.041-0.26c0.386 1.353 1.431 2.398 2.756 2.777l0.028 0.007c2.491 0.669 12.528 0.669 12.528 0.669s10.008 0 12.528-0.669c1.353-0.386 2.398-1.431 2.777-2.756l0.007-0.028c0.425-2.233 0.668-4.803 0.668-7.429 0-0.099-0-0.198-0.001-0.297l0 0.015c0.001-0.092 0.001-0.201 0.001-0.31 0-2.626-0.243-5.196-0.708-7.687l0.040 0.258zM12.812 20.801v-9.591l8.352 4.803z"></path></svg> YouTube</a></li>
         <li><a href="https://www.w3.org/WAI/news/subscribe/" class="button">Get News in Email</a></li>
       </ul>
-    </div>
+    </div-->
     <div dir="auto" translate="no" lang="en">
       <p>Copyright © 2025 World Wide Web Consortium (<a href="https://www.w3.org/">W3C</a><sup>®</sup>). See <a href="/WAI/about/using-wai-material/">Permission to Use WAI Material</a>.</p>
     </div>
   </div>
-  <div dir="auto" translate="no" class="q4-start q4-end" lang="en">
+  <!--div dir="auto" translate="no" class="q4-start q4-end" lang="en">
     <ul style="margin-bottom:0">
       <li><a href="/WAI/about/contacting/">Contact WAI</a></li>
       <li><a href="/WAI/sitemap/">Site Map</a></li>
@@ -241,7 +241,7 @@
       <li><a href="/WAI/translations/"> Translations</a></li>
       <li><a href="/WAI/roles/">Resources for Roles</a></li>
     </ul>
-  </div>
+  </div-->
 </footer>
 
 <link rel="stylesheet" href="../a11y-light.css">
@@ -255,7 +255,7 @@
 </script>
 <script src="https://www.w3.org/WAI/assets/scripts/main.js"></script>
 
-<script>
+<!--script>
   var _paq = _paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
   _paq.push(["setDoNotTrack", true]);
@@ -271,7 +271,7 @@
 </script>
 <noscript>
   <p><img src="//www.w3.org/analytics/piwik/piwik.php?idsite=328&amp;rec=1" style="border:0;" alt="" /></p>
-</noscript>
-
+</noscript-->
+<script src="https://waic.jp/docs/js/translation-contact.js"></script>
 
 </body></html>


### PR DESCRIPTION
Close https://github.com/waic/wcag22/issues/889

H64の翻訳です。

raw.githack.com
https://raw.githack.com/waic/wcag22/momdo-H64/techniques/html/H64.html

@caztcha
レビューをお願いします。

`frame`が削除されているので、全面的に訳を起こしました。