### PR TITLE
テクニック集の表紙の翻訳・リンクタイトルの置換（2025-07）

### DIFF
--- a/techniques/aria/ARIA11.html
+++ b/techniques/aria/ARIA11.html
@@ -238,7 +238,7 @@
          <li><a href="../general/G1">G1: Adding a link at the top of each page that goes directly to the main content area</a></li>
          <li><a href="../general/G124">G124: Adding links at the top of the page to each area of the content</a></li>
          <li><a href="../html/H69">H69: Providing heading elements at the beginning of each section of content</a></li>
-         <li><a href="../html/H100">H100: Providing properly marked up email and password inputs</a></li>
+         <li><a href="../html/H100">H100: 適切にマークアップされた電子メール及びパスワードの入力を提供する</a></li>
          <li><a href="../client-side-script/SCR28">SCR28: Using an expandable and collapsible menu to bypass block of content</a></li>
       </ul>
    </section>

--- a/techniques/css/C15.html
+++ b/techniques/css/C15.html
@@ -202,7 +202,7 @@
          <li><a href="../general/G165">G165: Using the default focus indicator for the platform so that high visibility default focus indicators will carry over</a></li>
          <li><a href="../general/G195">G195: Using an author-supplied, visible focus indicator</a></li>
          <li><a href="../css/C40">C40: Creating a two-color focus indicator to ensure sufficient contrast with all components</a></li>
-         <li><a href="../css/C45">C45: Using CSS :focus-visible to provide keyboard focus indication</a></li>
+         <li><a href="../css/C45">C45: CSS の :focus-visible を用いてキーボードフォーカス表示を提供する</a></li>
       </ul>
     </section>
 <section id="tests"><h2>Tests</h2>

--- a/techniques/css/C40.html
+++ b/techniques/css/C40.html
@@ -167,7 +167,7 @@
 				<li><a href="../general/G195">G195: Using an author-supplied, visible focus indicator</a></li>
 				<li><a href="../css/C15">C15: Using CSS to change the presentation of a user interface component when it receives focus</a></li>
 				<li><a href="../general/G165">G165: Using the default focus indicator for the platform so that high visibility default focus indicators will carry over</a></li>
-        <li><a href="../css/C45">C45: Using CSS :focus-visible to provide keyboard focus indication</a></li>
+        <li><a href="../css/C45">C45: CSS の :focus-visible を用いてキーボードフォーカス表示を提供する</a></li>
 			</ul>
 		</section>
 <section id="tests">

--- a/techniques/failures/F96.html
+++ b/techniques/failures/F96.html
@@ -136,7 +136,7 @@
 <section id="related">
 			<h2>Related Techniques</h2>
 			<ul>
-				<li><a href="../failures/F111">F111: Failure of Success Criteria 1.3.1, 2.5.3, and 4.1.2 due to a control with visible label text but no accessible name</a></li>
+				<li><a href="../failures/F111">F111: 達成基準 1.3.1、2.5.3 及び 4.1.2 の失敗例 ― 可視のラベルはあるがアクセシブルな名前 (name) がないコントロール</a></li>
         <li><a href="../general/G131">G131: Providing descriptive labels</a></li>
         <li><a href="../aria/ARIA7">ARIA7: Using aria-labelledby for link purpose</a></li>
         <li><a href="../aria/ARIA8">ARIA8: Using aria-label for link purpose</a></li>

--- a/techniques/general/G165.html
+++ b/techniques/general/G165.html
@@ -108,7 +108,7 @@
       <li><a href="../css/C15">C15: Using CSS to change the presentation of a user interface component when it receives focus</a></li>
       <li><a href="../general/G195">G195: Using an author-supplied, visible focus indicator</a></li>
       <li><a href="../css/C40">C40: Creating a two-color focus indicator to ensure sufficient contrast with all components</a></li>
-      <li><a href="../css/C45">C45: Using CSS :focus-visible to provide keyboard focus indication</a></li>
+      <li><a href="../css/C45">C45: CSS の :focus-visible を用いてキーボードフォーカス表示を提供する</a></li>
    </ul></section>
 <section id="tests"><h2>Tests</h2>
       <section class="procedure" id="procedure"><h3>Procedure</h3>

--- a/techniques/general/G195.html
+++ b/techniques/general/G195.html
@@ -134,7 +134,7 @@
       <li><a href="../css/C15">C15: Using CSS to change the presentation of a user interface component when it receives focus</a></li>
       <li><a href="../client-side-script/SCR31">SCR31: Using script to change the background color or border of the element with focus</a></li>
       <li><a href="../css/C40">C40: Creating a two-color focus indicator to ensure sufficient contrast with all components</a></li>
-      <li><a href="../css/C45">C45: Using CSS :focus-visible to provide keyboard focus indication</a></li>
+      <li><a href="../css/C45">C45: CSS の :focus-visible を用いてキーボードフォーカス表示を提供する</a></li>
    </ul></section>
 <section id="tests"><h2>Tests</h2>
       <section class="procedure" id="procedure"><h3>Procedure</h3>

--- a/techniques/general/G59.html
+++ b/techniques/general/G59.html
@@ -101,7 +101,7 @@
       <li><a href="../css/C27">C27: Making the DOM order match the visual order</a></li>
       <li><a href="../client-side-script/SCR26">SCR26: Inserting dynamic content into the Document Object Model immediately following its trigger element</a></li>
       <li><a href="../client-side-script/SCR27">SCR27: Reordering page sections using the Document Object Model</a></li>
-      <li><a href="../html/H102">H102: Creating modal dialogs with the HTML dialog element</a></li>
+      <li><a href="../html/H102">H102: HTML dialog 要素を用いてモーダルダイアログを作成する</a></li>
    </ul></section>
 <section id="tests"><h2>Tests</h2>
       <section class="procedure" id="procedure"><h3>Procedure</h3>

--- a/techniques/index.html
+++ b/techniques/index.html
@@ -1,8 +1,8 @@
-<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"><head>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="ja" xml:lang="ja"><head>
 		<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 		
-		<title>All WCAG 2.2 Techniques | WAI | W3C</title>
+		<title>WCAG 2.2 テクニック集 | WAI | W3C</title>
 		<link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
 		<link rel="stylesheet" type="text/css" href="base.css">
 	</head>
@@ -12,12 +12,12 @@
 <div class="minimal-header-container default-grid">
   <header class="minimal-header" id="site-header">
     <div class="minimal-header-name">
-      <a href="https://w3c.github.io/wcag/techniques/">WCAG 2.2 Techniques</a>
+      <a href="https://waic.jp/translations/WCAG22/Techniques/">WCAG 2.2 テクニック集</a>
     </div>
     
       <div class="minimal-header-subtitle">Examples of ways to meet WCAG; not required</div>
     
-    <a class="minimal-header-link" href="https://w3c.github.io/wcag/techniques/about">About WCAG Techniques</a>
+    <a class="minimal-header-link" href="https://waic.jp/translations/WCAG22/Techniques/about">WCAG テクニック集について</a>
     <div class="minimal-header-logo">
       <a href="http://w3.org/" aria-label="W3C">
         <svg xmlns="http://www.w3.org/2000/svg" height="2em" viewBox="0 0 91.968 44">
@@ -1102,12 +1102,15 @@
       <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide</a> project,
       co-funded by the European Commission.
     </p>
+    <p>この文書は、2025 年 5 月 21 日付けの <a href="https://w3c.github.io/wcag/techniques/">Techniques for WCAG 2.2</a> を、<a href="https://waic.jp/">ウェブアクセシビリティ基盤委員会 (WAIC)</a> の翻訳ワーキンググループが翻訳して公開しているものです。この文書の正式版は、W3C のサイトにある英語版です。正確な内容については、W3C が公開している原文 (英語) をご確認ください。この翻訳文書は作業進行中です。また、あくまで参考情報であり、翻訳上の誤りが含まれていることがあります。
+    </p>
+    <p>この翻訳文書の利用条件については、<a href="https://waic.jp/license-for-translated-documents/">WAICが提供する翻訳文書のライセンス</a>をご覧ください。</p>
   </div>
 </footer>
 
 <footer class="site-footer grid-4q" aria-label="Site">
   <div class="q1-start q3-end about">
-    <div>
+    <!--div>
       <p><a class="largelink" href="https://www.w3.org/WAI/" dir="auto" translate="no" lang="en">W3C Web Accessibility Initiative (WAI)</a></p>
       <p>Strategies, standards, and supporting resources to make the Web accessible to people with disabilities.</p>
     </div>
@@ -1118,12 +1121,12 @@
         <li><a href="https://www.youtube.com/channel/UCU6ljj3m1fglIPjSjs2DpRA/playlistsv"><svg focusable="false" aria-hidden="true" class="icon-youtube " viewBox="0 0 32 32"><path d="M31.327 8.273c-0.386-1.353-1.431-2.398-2.756-2.777l-0.028-0.007c-2.493-0.668-12.528-0.668-12.528-0.668s-10.009-0.013-12.528 0.668c-1.353 0.386-2.398 1.431-2.777 2.756l-0.007 0.028c-0.443 2.281-0.696 4.903-0.696 7.585 0 0.054 0 0.109 0 0.163l-0-0.008c-0 0.037-0 0.082-0 0.126 0 2.682 0.253 5.304 0.737 7.845l-0.041-0.26c0.386 1.353 1.431 2.398 2.756 2.777l0.028 0.007c2.491 0.669 12.528 0.669 12.528 0.669s10.008 0 12.528-0.669c1.353-0.386 2.398-1.431 2.777-2.756l0.007-0.028c0.425-2.233 0.668-4.803 0.668-7.429 0-0.099-0-0.198-0.001-0.297l0 0.015c0.001-0.092 0.001-0.201 0.001-0.31 0-2.626-0.243-5.196-0.708-7.687l0.040 0.258zM12.812 20.801v-9.591l8.352 4.803z"></path></svg> YouTube</a></li>
         <li><a href="https://www.w3.org/WAI/news/subscribe/" class="button">Get News in Email</a></li>
       </ul>
-    </div>
+    </div-->
     <div dir="auto" translate="no" lang="en">
       <p>Copyright © 2025 World Wide Web Consortium (<a href="https://www.w3.org/">W3C</a><sup>®</sup>). See <a href="/WAI/about/using-wai-material/">Permission to Use WAI Material</a>.</p>
     </div>
   </div>
-  <div dir="auto" translate="no" class="q4-start q4-end" lang="en">
+  <!--div dir="auto" translate="no" class="q4-start q4-end" lang="en">
     <ul style="margin-bottom:0">
       <li><a href="/WAI/about/contacting/">Contact WAI</a></li>
       <li><a href="/WAI/sitemap/">Site Map</a></li>
@@ -1132,7 +1135,7 @@
       <li><a href="/WAI/translations/"> Translations</a></li>
       <li><a href="/WAI/roles/">Resources for Roles</a></li>
     </ul>
-  </div>
+  </div-->
 </footer>
 
 </body></html>

--- a/techniques/index.html
+++ b/techniques/index.html
@@ -49,16 +49,16 @@
       
       <div class="default-grid with-gap leftcol">
          <aside class="box nav-hack sidebar standalone-resource__sidebar ">
-           <header class="box-h ">Page Contents</header>
+           <header class="box-h ">このページの内容</header>
            <div class="box-i">
               <nav aria-label="page contents" class="navtoc">
                   <ul>
                      <li><a href="#aria">ARIA Techniques</a></li>
                      <li><a href="#client-side-script">Client-Side Script Techniques</a></li>
-                     <li><a href="#css">CSS Techniques</a></li>
-                     <li><a href="#failures">Common Failures</a></li>
-                     <li><a href="#general">General Techniques</a></li>
-                     <li><a href="#html">HTML Techniques</a></li>
+                     <li><a href="#css">CSS のテクニック</a></li>
+                     <li><a href="#failures">よくある失敗例</a></li>
+                     <li><a href="#general">一般的なテクニック</a></li>
+                     <li><a href="#html">HTML のテクニック</a></li>
                      <li><a href="#pdf">PDF Techniques</a></li>
                      <li><a href="#server-side-script">Server-Side Script Techniques</a></li>
                      <li><a href="#smil">SMIL Techniques</a></li>
@@ -70,11 +70,11 @@
          </aside>
 
 			<main id="main" class="main-content standalone-resource__main">
-				<h1 id="title" class="title p-name">Techniques for WCAG 2.2</h1>
+				<h1 id="title" class="title p-name">WCAG 2.2 テクニック集</h1>
 		<aside class="box">
-			<header class="box-h ">Summary</header>
+			<header class="box-h ">概要</header>
 			<div class="box-i">
-				<p><em>Techniques</em> are examples of ways to meet Web Content Accessibility Guidelines (WCAG). They are not required to meet WCAG. For information, see <a href="about">About WCAG Techniques</a>.</p>
+				<p><em>テクニック集</em>は、ウェブコンテンツアクセシビリティガイドライン (WCAG) を満たすための方法の例である。WCAGに満たすために必須ではない。詳細については、<a href="about">WCAGテクニックについて</a>を参照。</p>
 			</div>
 		</aside>
 		
@@ -180,7 +180,7 @@
       <li><a href="client-side-script/SCR39">SCR39: Making content on focus or hover hoverable, dismissible, and persistent</a></li>
       
     </ul>
-  <h2 id="css">CSS Techniques<span class="permalink"><a href="#css" aria-label="Permalink for CSS Techniques" title="Permalink for CSS Techniques"><span>§</span></a></span></h2>
+  <h2 id="css">CSS のテクニック<span class="permalink"><a href="#css" aria-label="Permalink for CSS Techniques" title="Permalink for CSS Techniques"><span>§</span></a></span></h2>
 
     <ul class="toc-wcag-docs">
       
@@ -246,16 +246,16 @@
       
       <li><a href="css/C40">C40: Creating a two-color focus indicator to ensure sufficient contrast with all components</a></li>
       
-      <li><a href="css/C41">C41: Creating a strong focus indicator within the component</a></li>
+      <li><a href="css/C41">C41: コンポーネント内に堅固なフォーカスインジケータを作成する</a></li>
       
-      <li><a href="css/C42">C42: Using min-height and min-width to ensure sufficient target spacing</a></li>
+      <li><a href="css/C42">C42: min-height 及び min-width を用いてターゲットの間隔を確保する</a></li>
       
-      <li><a href="css/C43">C43: Using CSS scroll-padding to un-obscure content</a></li>
+      <li><a href="css/C43">C43: CSS の scroll-padding を用いてコンテンツを隠さないようにする</a></li>
       
-      <li><a href="css/C45">C45: Using CSS :focus-visible to provide keyboard focus indication</a></li>
+      <li><a href="css/C45">C45: CSS の :focus-visible を用いてキーボードフォーカス表示を提供する</a></li>
       
     </ul>
-  <h2 id="failures">Common Failures<span class="permalink"><a href="#failures" aria-label="Permalink for Common Failures" title="Permalink for Common Failures"><span>§</span></a></span></h2>
+  <h2 id="failures">よくある失敗例<span class="permalink"><a href="#failures" aria-label="Permalink for Common Failures" title="Permalink for Common Failures"><span>§</span></a></span></h2>
 
     <ul class="toc-wcag-docs">
       
@@ -456,18 +456,18 @@
       
       <li><a href="failures/F107">F107: Failure of Success Criterion 1.3.5 due to incorrect autocomplete attribute values</a></li>
       
-      <li><a href="failures/F108">F108: Failure of Success Criterion 2.5.7 Dragging Movements due to not providing a single pointer method that does not require a dragging movement</a></li>
+      <li><a href="failures/F108">F108: 達成基準 2.5.7 ドラッグ動作の失敗例 ― ドラッグ動作を必要としないシングルポインタの手段を提供していない</a></li>
       
-      <li><a href="failures/F109">F109: Failure of Success Criterion 3.3.8 and 3.3.9 due to preventing password or code re-entry in the same format</a></li>
+      <li><a href="failures/F109">F109: 達成基準 3.3.8 及び 3.3.9 の失敗例 ― 同じ形式でのパスワード又はコードの再入力を妨げる</a></li>
       
-      <li><a href="failures/F110">F110: Failure of Success Criterion 2.4.11 Focus Not Obscured (Minimum) due to a sticky footer or header completely hiding focused elements</a></li>
+      <li><a href="failures/F110">F110: 達成基準 2.4.11 隠されないフォーカス (最低限) の失敗例 ― フォーカスされた要素を完全に隠す固定フッター又はヘッダー</a></li>
       
-      <li><a href="failures/F111">F111: Failure of Success Criteria 1.3.1, 2.5.3, and 4.1.2 due to a control with visible label text but no accessible name</a></li>
+      <li><a href="failures/F111">F111: 達成基準 1.3.1、2.5.3 及び 4.1.2 の失敗例 ― 可視のラベルはあるがアクセシブルな名前 (name) がないコントロール</a></li>
       
-      <li><a href="failures/F112">F112: Failure of Success Criterion 2.2.2 due to using blinking content that lasts for more than five seconds without a mechanism to stop it</a></li>
+      <li><a href="failures/F112">F112: 達成基準 2.2.2 の失敗例 ― 停止するメカニズムなしに 5 秒よりも長く点滅するコンテンツを使用している</a></li>
       
     </ul>
-  <h2 id="general">General Techniques<span class="permalink"><a href="#general" aria-label="Permalink for General Techniques" title="Permalink for General Techniques"><span>§</span></a></span></h2>
+  <h2 id="general">一般的なテクニック<span class="permalink"><a href="#general" aria-label="Permalink for General Techniques" title="Permalink for General Techniques"><span>§</span></a></span></h2>
 
     <ul class="toc-wcag-docs">
       
@@ -798,22 +798,22 @@
       
       <li><a href="general/G217">G217: Providing a mechanism to allow users to remap or turn off character key shortcuts</a></li>
       
-      <li><a href="general/G218">G218: Email link authentication</a></li>
+      <li><a href="general/G218">G218: 電子メールリンクによる認証</a></li>
       
-      <li><a href="general/G219">G219: Ensuring that an alternative is available for dragging movements that operate on content</a></li>
+      <li><a href="general/G219">G219: コンテンツを操作するドラッグ動作の代替手段を利用可能にする</a></li>
       
-      <li><a href="general/G220">G220: Provide a contact-us link in a consistent location</a></li>
+      <li><a href="general/G220">G220: 問い合わせリンクを一貫した場所に提供する</a></li>
       
-      <li><a href="general/G221">G221: Provide data from a previous step in a process</a></li>
+      <li><a href="general/G221">G221: プロセスの以前のステップからデータを提供する</a></li>
       
-      <li><a href="general/G223">G223: Using an author-supplied, highly visible focus indicator</a></li>
+      <li><a href="general/G223">G223: コンテンツ制作者が提供した視認性の高いフォーカスインジケータを用いる</a></li>
       
-      <li><a href="general/G224">G224: Accounting for meaningful text indentation and Reflow</a></li>
+      <li><a href="general/G224">G224: 意味のあるテキストのインデント及びリフローを考慮する</a></li>
       
-      <li><a href="general/G225">G225: Section panels that scroll horizontally are designed to fit within a width of 320 CSS pixels on a vertically scrolling page</a></li>
+      <li><a href="general/G225">G225: 垂直にスクロールするページで 320 CSS ピクセルの幅に収まるように設計されている、水平にスクロールするセクションパネル</a></li>
       
     </ul>
-  <h2 id="html">HTML Techniques<span class="permalink"><a href="#html" aria-label="Permalink for HTML Techniques" title="Permalink for HTML Techniques"><span>§</span></a></span></h2>
+  <h2 id="html">HTML のテクニック<span class="permalink"><a href="#html" aria-label="Permalink for HTML Techniques" title="Permalink for HTML Techniques"><span>§</span></a></span></h2>
 
     <ul class="toc-wcag-docs">
       
@@ -914,13 +914,13 @@
       
       <li><a href="html/H98">H98: Using HTML 5.2 autocomplete attributes</a></li>
       
-      <li><a href="html/H99">H99: Provide a page-selection mechanism</a></li>
+      <li><a href="html/H99">H99: ページ選択メカニズムを提供する</a></li>
       
-      <li><a href="html/H100">H100: Providing properly marked up email and password inputs</a></li>
+      <li><a href="html/H100">H100: 適切にマークアップされた電子メール及びパスワードの入力を提供する</a></li>
       
-      <li><a href="html/H101">H101: Using semantic HTML elements to identify regions of a page</a></li>
+      <li><a href="html/H101">H101: セマンティックな HTML 要素を用いてページの領域を識別する</a></li>
       
-      <li><a href="html/H102">H102: Creating modal dialogs with the HTML dialog element</a></li>
+      <li><a href="html/H102">H102: HTML dialog 要素を用いてモーダルダイアログを作成する</a></li>
       
     </ul>
   <h2 id="pdf">PDF Techniques<span class="permalink"><a href="#pdf" aria-label="Permalink for PDF Techniques" title="Permalink for PDF Techniques"><span>§</span></a></span></h2>

--- a/understanding/accessible-authentication-enhanced.html
+++ b/understanding/accessible-authentication-enhanced.html
@@ -199,12 +199,12 @@
                   <ul>
                      
                      <li>
-                        <a class="general" href="https://w3c.github.io/wcag/techniques/general/G218">G218: Email link authentication</a>
+                        <a class="general" href="https://waic.jp/translations/WCAG22/Techniques/general/G218">G218: 電子メールリンクによる認証</a>
                         
                      </li>
                      
                      <li>
-                        <a class="html" href="https://w3c.github.io/wcag/techniques/html/H100">H100: Providing properly marked up email and password inputs</a>
+                        <a class="html" href="https://waic.jp/translations/WCAG22/Techniques/html/H100">H100: 適切にマークアップされた電子メール及びパスワードの入力を提供する</a>
                         
                      </li>
                      
@@ -232,8 +232,7 @@
                   <ul>
                      
                      <li>
-                        <a href="https://w3c.github.io/wcag/techniques/failures/F109">F109: Failure of Success Criterion 3.3.8 and 3.3.9 due to preventing password or code re-entry
-                           in the same format</a>
+                        <a href="https://waic.jp/translations/WCAG22/Techniques/failures/F109">F109: 達成基準 3.3.8 及び 3.3.9 の失敗例 ― 同じ形式でのパスワード又はコードの再入力を妨げる</a>
                         
                      </li>
                      
@@ -561,7 +560,7 @@
             </ul>
          </div-->
       </footer>
-      <link rel="stylesheet" href="../a11y-light.css" /><script src="../highlight.min.js"></script><script>
+      <link rel="stylesheet" href="../a11y-light.css" /><script src="../highlight.min.js"></script><!--script>
       hljs.configure({
         cssSelector: 'pre'
       });
@@ -580,7 +579,7 @@
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
         g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
       })();
-    </script>
+    </script-->
     <script src="https://waic.jp/docs/js/translation-contact.js"></script>
     <!--noscript>
          <p><img src="//www.w3.org/analytics/piwik/piwik.php?idsite=328&amp;rec=1" style="border:0;" alt="" /></p>

--- a/understanding/accessible-authentication-minimum.html
+++ b/understanding/accessible-authentication-minimum.html
@@ -321,7 +321,7 @@
                   
                   <li><a href="https://w3c.github.io/coga/issue-papers/#web-security-and-privacy-technologies">Cognitive Accessibility Issue Papers 4. Web Security and Privacy Technologies</a> and <a href="https://w3c.github.io/coga/issue-papers/privacy-security.html">Web Security and Privacy Technologies</a></li>
                   
-                  <li><a href="https://www.w3.org/TR/coga-usable/#provide-a-login-that-does-not-rely-on-memory-or-other-             cognitive-skills-pattern">Making Content Usable for People with Cognitive and Learning Disabilities 4.7.1 Provide
+                  <li><a href="https://www.w3.org/TR/coga-usable/#provide-a-login-that-does-not-rely-on-memory-or-other-cognitive-skills-pattern">Making Content Usable for People with Cognitive and Learning Disabilities 4.7.1 Provide
                         a Login that Does Not Rely on Memory or Other Cognitive Skills</a></li>
                   
                   <li><a href="https://www.w3.org/TR/webauthn/">WebAuthN specification</a></li>
@@ -345,12 +345,12 @@
                   <ul>
                      
                      <li>
-                        <a class="general" href="https://w3c.github.io/wcag/techniques/general/G218">G218: Email link authentication</a>
+                        <a class="general" href="https://waic.jp/translations/WCAG22/Techniques/general/G218">G218: 電子メールリンクによる認証</a>
                         
                      </li>
                      
                      <li>
-                        <a class="html" href="https://w3c.github.io/wcag/techniques/html/H100">H100: Providing properly marked up email and password inputs</a>
+                        <a class="html" href="https://waic.jp/translations/WCAG22/Techniques/html/H100">H100: 適切にマークアップされた電子メール及びパスワードの入力を提供する</a>
                         
                      </li>
                      
@@ -378,8 +378,7 @@
                   <ul>
                      
                      <li>
-                        <a href="https://w3c.github.io/wcag/techniques/failures/F109">F109: Failure of Success Criterion 3.3.8 and 3.3.9 due to preventing password or code re-entry
-                           in the same format</a>
+                        <a href="https://waic.jp/translations/WCAG22/Techniques/failures/F109">F109: 達成基準 3.3.8 及び 3.3.9 の失敗例 ― 同じ形式でのパスワード又はコードの再入力を妨げる</a>
                         
                      </li>
                      
@@ -801,7 +800,7 @@
             </ul>
          </div-->
       </footer>
-      <link rel="stylesheet" href="../a11y-light.css" /><script src="../highlight.min.js"></script><script>
+      <link rel="stylesheet" href="../a11y-light.css" /><script src="../highlight.min.js"></script><!--script>
       hljs.configure({
         cssSelector: 'pre'
       });
@@ -820,7 +819,7 @@
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
         g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
       })();
-    </script>
+    </script-->
     <script src="https://waic.jp/docs/js/translation-contact.js"></script>
     <!--noscript>
          <p><img src="//www.w3.org/analytics/piwik/piwik.php?idsite=328&amp;rec=1" style="border:0;" alt="" /></p>

--- a/understanding/consistent-help.html
+++ b/understanding/consistent-help.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="ja" xml:lang="ja">
    <head>
       <meta charset="UTF-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -275,7 +275,7 @@
                   
                   <li><a href="https://www.w3.org/TR/coga-gap-analysis/#table6">Cognitive Accessibility Gap Analysis Topic 6: Familiar Interface</a></li>
                   
-                  <li><a href="https://www.w3.org/TR/coga-usable/#make-it-easy-             to-find-help-and-give-feedback-pattern">Making Content Usable for People with Cogntive and Learning Disabilities 4.8.5 Make
+                  <li><a href="https://www.w3.org/TR/coga-usable/#make-it-easy-to-find-help-and-give-feedback-pattern">Making Content Usable for People with Cogntive and Learning Disabilities 4.8.5 Make
                         it Easy to Find Help and Give Feedback</a></li>
                   
                </ul>
@@ -288,7 +288,7 @@
                   <h3>十分なテクニック</h3>
                   <ol>
                      
-                     <li><a class="general" href="https://w3c.github.io/wcag/techniques/general/G220">G220: Provide a contact-us link in a consistent location</a></li>
+                     <li><a class="general" href="https://waic.jp/translations/WCAG22/Techniques/general/G220">G220: 問い合わせリンクを一貫した場所に提供する</a></li>
                      
                   </ol>
                </section>
@@ -696,7 +696,7 @@
             </ul>
          </div-->
       </footer>
-      <link rel="stylesheet" href="../a11y-light.css" /><script src="../highlight.min.js"></script><script>
+      <link rel="stylesheet" href="../a11y-light.css" /><script src="../highlight.min.js"></script><!--script>
       hljs.configure({
         cssSelector: 'pre'
       });
@@ -715,7 +715,7 @@
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
         g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
       })();
-    </script>
+    </script-->
     <script src="https://waic.jp/docs/js/translation-contact.js"></script>
     <!--noscript>
          <p><img src="//www.w3.org/analytics/piwik/piwik.php?idsite=328&amp;rec=1" style="border:0;" alt="" /></p>

--- a/understanding/dragging-movements.html
+++ b/understanding/dragging-movements.html
@@ -207,7 +207,7 @@
                   <ol>
                      
                      <li>
-                        <a class="general" href="https://w3c.github.io/wcag/techniques/general/G219">G219: Ensuring that an alternative is available for dragging movements that operate on content</a>
+                        <a class="general" href="https://waic.jp/translations/WCAG22/Techniques//general/G219">G219: コンテンツを操作するドラッグ動作の代替手段を利用可能にする</a>
                         
                      </li>
                      
@@ -220,9 +220,7 @@
                   <ul>
                      
                      <li>								         
-                        <a class="failure" href="https://w3c.github.io/wcag/techniques/failures/F108">F108: Failure of Success Criterion 2.5.7 Dragging Movements due to not providing a single
-                           pointer method for the user to operate a function that does not require a dragging
-                           movement</a>						       
+                        <a class="failure" href="https://waic.jp/translations/WCAG22/Techniques/failures/F108">F108: 達成基準 2.5.7 ドラッグ動作の失敗例 ― ドラッグ動作を必要としないシングルポインタの手段を提供していない</a>						       
                         
                      </li>
                      
@@ -512,7 +510,7 @@
             </ul>
          </div-->
       </footer>
-      <link rel="stylesheet" href="../a11y-light.css" /><script src="../highlight.min.js"></script><script>
+      <link rel="stylesheet" href="../a11y-light.css" /><script src="../highlight.min.js"></script><!--script>
       hljs.configure({
         cssSelector: 'pre'
       });
@@ -531,7 +529,7 @@
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
         g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
       })();
-    </script>
+    </script-->
     <script src="https://waic.jp/docs/js/translation-contact.js"></script>
     <!--noscript>
          <p><img src="//www.w3.org/analytics/piwik/piwik.php?idsite=328&amp;rec=1" style="border:0;" alt="" /></p>

--- a/understanding/focus-appearance.html
+++ b/understanding/focus-appearance.html
@@ -869,7 +869,7 @@
                      </li>
                      
                      <li>
-                        <a href="https://w3c.github.io/wcag/techniques/css/C41">C41: Creating a strong focus indicator within the component</a>
+                        <a href="https://waic.jp/translations/WCAG22/Techniques/css/C41">C41: コンポーネント内に堅固なフォーカスインジケータを作成する</a>
                         
                      </li>
                      
@@ -1410,7 +1410,7 @@
       });
       hljs.highlightAll();
 			var translationStrings = {}; /* fix WAI JS */
-		</script><script src="https://www.w3.org/WAI/assets/scripts/main.js"></script><script>
+		</script><script src="https://www.w3.org/WAI/assets/scripts/main.js"></script><!--script>
       var _paq = _paq || [];
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       _paq.push(["setDoNotTrack", true]);
@@ -1423,7 +1423,7 @@
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
         g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
       })();
-    </script>
+    </script-->
     <script src="https://waic.jp/docs/js/translation-contact.js"></script>
     <!--noscript>
          <p><img src="//www.w3.org/analytics/piwik/piwik.php?idsite=328&amp;rec=1" style="border:0;" alt="" /></p>

--- a/understanding/focus-not-obscured-enhanced.html
+++ b/understanding/focus-not-obscured-enhanced.html
@@ -145,7 +145,7 @@
                   <h3>十分なテクニック</h3>
                   <ol>
                      
-                     <li> <a href="https://w3c.github.io/wcag/techniques/css/C43">C43: Using CSS scroll-padding to un-obscure content</a></li>
+                     <li> <a href="https://waic.jp/translations/WCAG22/Techniques/css/C43">C43: CSS の scroll-padding を用いてコンテンツを隠さないようにする</a></li>
                      
                   </ol>
                </section>
@@ -290,7 +290,7 @@
             </ul>
          </div-->
       </footer>
-      <link rel="stylesheet" href="../a11y-light.css" /><script src="../highlight.min.js"></script><script>
+      <link rel="stylesheet" href="../a11y-light.css" /><script src="../highlight.min.js"></script><!--script>
       hljs.configure({
         cssSelector: 'pre'
       });
@@ -309,7 +309,7 @@
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
         g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
       })();
-    </script>
+    </script-->
     <script src="https://waic.jp/docs/js/translation-contact.js"></script>
     <!--noscript>
          <p><img src="//www.w3.org/analytics/piwik/piwik.php?idsite=328&amp;rec=1" style="border:0;" alt="" /></p>

--- a/understanding/focus-not-obscured-minimum.html
+++ b/understanding/focus-not-obscured-minimum.html
@@ -334,7 +334,7 @@
                   <ol>
                      
                      <li>
-                        <a href="https://w3c.github.io/wcag/techniques/css/C43">C43: Using CSS scroll-padding to un-obscure content</a>
+                        <a href="https://waic.jp/translations/WCAG22/Techniques/css/C43">C43: CSS の scroll-padding を用いてコンテンツを隠さないようにする</a>
                         
                      </li>
                      
@@ -347,8 +347,7 @@
                   <ol>
                      
                      <li>
-                        <a href="https://w3c.github.io/wcag/techniques/failures/F110">F110: Failure of Success Criterion 2.4.12 Focus Not Obscured (Minimum) due to a sticky footer
-                           or header completely hiding focused elements</a>
+                        <a href="https://waic.jp/translations/WCAG22/Techniques/failures/F110">F110: 達成基準 2.4.11 隠されないフォーカス (最低限) の失敗例 ― フォーカスされた要素を完全に隠す固定フッター又はヘッダー</a>
                         
                      </li>
                      
@@ -481,7 +480,7 @@
             </ul>
          </div-->
       </footer>
-      <link rel="stylesheet" href="../a11y-light.css" /><script src="../highlight.min.js"></script><script>
+      <link rel="stylesheet" href="../a11y-light.css" /><script src="../highlight.min.js"></script><!--script>
       hljs.configure({
         cssSelector: 'pre'
       });
@@ -500,7 +499,7 @@
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
         g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
       })();
-    </script>
+    </script-->
     <script src="https://waic.jp/docs/js/translation-contact.js"></script>
     <!--noscript>
          <p><img src="//www.w3.org/analytics/piwik/piwik.php?idsite=328&amp;rec=1" style="border:0;" alt="" /></p>

--- a/understanding/focus-order.html
+++ b/understanding/focus-order.html
@@ -296,7 +296,7 @@
                            
                            <li>
                               											             
-                              <a class="script" href="https://w3c.github.io/wcag/techniques/html/H102">H102: Creating modal dialogs with the HTML dialog element</a>
+                              <a class="script" href="https://waic.jp/translations/WCAG22/Techniques/html/H102">H102: HTML dialog 要素を用いてモーダルダイアログを作成する</a>
                               										           
                               
                            </li>
@@ -635,7 +635,7 @@
             </ul>
          </div-->
       </footer>
-      <link rel="stylesheet" href="../a11y-light.css" /><script src="../highlight.min.js"></script><script>
+      <link rel="stylesheet" href="../a11y-light.css" /><script src="../highlight.min.js"></script><!--script>
       hljs.configure({
         cssSelector: 'pre'
       });
@@ -654,7 +654,7 @@
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
         g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
       })();
-    </script>
+    </script-->
     <script src="https://waic.jp/docs/js/translation-contact.js"></script>
     <!--noscript>
          <p><img src="//www.w3.org/analytics/piwik/piwik.php?idsite=328&amp;rec=1" style="border:0;" alt="" /></p>

--- a/understanding/info-and-relationships.html
+++ b/understanding/info-and-relationships.html
@@ -234,7 +234,7 @@
                      
                      <li>
                            
-                           <a class="aria" href="https://w3c.github.io/wcag/techniques/html/H101">H101: Using semantic HTML elements to identify regions of a page</a>
+                           <a class="aria" href="https://waic.jp/translations/WCAG22/Techniques/html/H101">H101: セマンティックな HTML 要素を用いてページの領域を識別する</a>
                            
                            
                      </li>
@@ -796,7 +796,7 @@
             </ul>
          </div-->
       </footer>
-      <link rel="stylesheet" href="../a11y-light.css" /><script src="../highlight.min.js"></script><script>
+      <link rel="stylesheet" href="../a11y-light.css" /><script src="../highlight.min.js"></script><!--script>
       hljs.configure({
         cssSelector: 'pre'
       });
@@ -815,7 +815,7 @@
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
         g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
       })();
-    </script>
+    </script-->
     <script src="https://waic.jp/docs/js/translation-contact.js"></script>
     <!--noscript>
          <p><img src="//www.w3.org/analytics/piwik/piwik.php?idsite=328&amp;rec=1" style="border:0;" alt="" /></p>

--- a/understanding/redundant-entry.html
+++ b/understanding/redundant-entry.html
@@ -208,7 +208,7 @@
                   <h3>十分なテクニック</h3>
                   <ul>
                      
-                     <li><a href="https://w3c.github.io/wcag/techniques/general/G221">G221: Provide data from a previous step in a process</a></li>
+                     <li><a href="https://waic.jp/translations/WCAG22/Techniques/general/G221">G221: プロセスの以前のステップからデータを提供する</a></li>
                      
                      <li>Not requesting the same information twice (Potential future technique)</li>
                      
@@ -336,7 +336,7 @@
             </ul>
          </div-->
       </footer>
-      <link rel="stylesheet" href="../a11y-light.css" /><script src="../highlight.min.js"></script><script>
+      <link rel="stylesheet" href="../a11y-light.css" /><script src="../highlight.min.js"></script><!--script>
       hljs.configure({
         cssSelector: 'pre'
       });
@@ -355,7 +355,7 @@
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
         g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
       })();
-    </script>
+    </script-->
     <script src="https://waic.jp/docs/js/translation-contact.js"></script>
     <!--noscript>
          <p><img src="//www.w3.org/analytics/piwik/piwik.php?idsite=328&amp;rec=1" style="border:0;" alt="" /></p>

--- a/understanding/target-size-minimum.html
+++ b/understanding/target-size-minimum.html
@@ -401,7 +401,7 @@
                   <ol>
                      
                      <li>
-                        <a class="css" href="https://w3c.github.io/wcag/techniques/css/C42">C42: Using min-height and min-width to ensure sufficient target spacing</a>
+                        <a class="css" href="https://waic.jp/translations/WCAG22/Techniques/css/C42">C42: min-height 及び min-width を用いてターゲットの間隔を確保する</a>
                         
                      </li>
                      
@@ -767,7 +767,7 @@
             </ul>
          </div-->
       </footer>
-      <link rel="stylesheet" href="../a11y-light.css" /><script src="../highlight.min.js"></script><script>
+      <link rel="stylesheet" href="../a11y-light.css" /><script src="../highlight.min.js"></script><!--script>
       hljs.configure({
         cssSelector: 'pre'
       });
@@ -786,7 +786,7 @@
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
         g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
       })();
-    </script>
+    </script-->
     <script src="https://waic.jp/docs/js/translation-contact.js"></script>
     <!--noscript>
          <p><img src="//www.w3.org/analytics/piwik/piwik.php?idsite=328&amp;rec=1" style="border:0;" alt="" /></p>


### PR DESCRIPTION
関連: #1046

@caztcha 

レビューをお願いします。主な変更点は下記のとおりです。

- indexの翻訳
  - 達成方法集はChange logが英語ママなのでそれに合わせています
- リンクタイトルの置換
  - 解説書だけでなく、テクニック集内のリンクも置換しています
- consistent-help.htmlの`lang`が`en`のままだったことに気づいたので修正（！）
- `<script>`のコメントアウト（今回変更のあったファイルのみ）
  - テクニック集に合わせました