### PR TITLE
Not Foundになっているeditors.cssの参照を削除

### DIFF
--- a/techniques/aria/ARIA22.html
+++ b/techniques/aria/ARIA22.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>ARIA22: Using role=status to present status messages | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/aria/ARIA23.html
+++ b/techniques/aria/ARIA23.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>ARIA23: Using role=log to identify sequential information updates | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/client-side-script/SCR39.html
+++ b/techniques/client-side-script/SCR39.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>SCR39: Making content on focus or hover hoverable, dismissible, and persistent | WAI | W3C</title>
-  <link rel="stylesheet" type="text/css" href="../../css/editors.css">
 
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/css/C38.html
+++ b/techniques/css/C38.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>C38: Using CSS width, max-width and flexbox to fit labels and inputs | WAI | W3C</title>
-    <link rel="stylesheet" type="text/css" href="../../css/editors.css">
   
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/css/C39.html
+++ b/techniques/css/C39.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>C39: Using the CSS reduce-motion query to prevent motion | WAI | W3C</title>
-  <link rel="stylesheet" type="text/css" href="../../css/editors.css">
 
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/css/C40.html
+++ b/techniques/css/C40.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>C40: Creating a two-color focus indicator to ensure sufficient contrast with all components | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/css/C41.html
+++ b/techniques/css/C41.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="ja"><head>
 <meta charset="UTF-8">
 <title>C41: コンポーネント内に堅固なフォーカスインジケータを作成する | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/css/C42.html
+++ b/techniques/css/C42.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="ja"><head>
 <meta charset="UTF-8">
 <title>C42: min-height 及び min-width を用いてターゲットの間隔を確保する | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/css/C43.html
+++ b/techniques/css/C43.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="ja"><head>
 <meta charset="UTF-8">
 <title>C43: CSS の scroll-padding を用いてコンテンツを隠さないようにする | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/css/C45.html
+++ b/techniques/css/C45.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="ja"><head>
 <meta charset="UTF-8">
 <title>C45: CSS の :focus-visible を用いてキーボードフォーカス表示を提供する | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/failures/F100.html
+++ b/techniques/failures/F100.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>F100: Failure of Success Criterion 1.3.4 due to showing a message asking to reorient device | WAI | W3C</title>
-    <link rel="stylesheet" type="text/css" href="../../css/editors.css">
   
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/failures/F101.html
+++ b/techniques/failures/F101.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>F101: Failure of Success Criterion 2.5.2 due to activating a control on the down-event | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/failures/F102.html
+++ b/techniques/failures/F102.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>F102: Failure of Success Criterion 1.4.10 due to content disappearing and not being available when content has reflowed | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/failures/F103.html
+++ b/techniques/failures/F103.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>F103: Failure of Success Criterion 4.1.3 due to providing status messages that cannot be programmatically determined through role or properties | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/failures/F104.html
+++ b/techniques/failures/F104.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>F104: Failure of Success Criterion 1.4.12 due to clipped or overlapped content when text spacing is adjusted | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/failures/F105.html
+++ b/techniques/failures/F105.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>F105: Failure of Success Criterion 2.5.1 due to providing functionality via a path-based gesture without simple pointer alternative | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/failures/F106.html
+++ b/techniques/failures/F106.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>F106: Failure due to inability to deactivate motion actuation | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/failures/F107.html
+++ b/techniques/failures/F107.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>F107: Failure of Success Criterion 1.3.5 due to incorrect autocomplete attribute values | WAI | W3C</title>
-      <link rel="stylesheet" type="text/css" href="../../css/editors.css">
 
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/failures/F108.html
+++ b/techniques/failures/F108.html
@@ -2,8 +2,6 @@
 <meta charset="UTF-8">
 <title>F108: 達成基準 2.5.7 ドラッグ動作の失敗例 ― ドラッグ動作を必要としないシングルポインタの手段を提供していない | WAI | W3C</title>
 
-      <link rel="stylesheet" type="text/css" href="../../css/editors.css">
-
 
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/failures/F109.html
+++ b/techniques/failures/F109.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html><html lang="ja" xml:lang="ja" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
 <title>F109: 達成基準 3.3.8 及び 3.3.9 の失敗例 ― 同じ形式でのパスワード又はコードの再入力を妨げる | WAI | W3C</title>
-   
-    <link rel="stylesheet" type="text/css" href="../../css/editors.css">
 
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/failures/F110.html
+++ b/techniques/failures/F110.html
@@ -1,7 +1,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="ja"><head>
 <meta charset="UTF-8">
 <title>F110: 達成基準 2.4.11 隠されないフォーカス (最低限) の失敗例 ― フォーカスされた要素を完全に隠す固定フッター又はヘッダー | WAI | W3C</title>
-			<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/failures/F111.html
+++ b/techniques/failures/F111.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="ja"><head>
 <meta charset="UTF-8">
 <title>F111: 達成基準 1.3.1、2.5.3 及び 4.1.2 の失敗例 ― 可視のラベルはあるがアクセシブルな名前 (name) がないコントロール | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/failures/F95.html
+++ b/techniques/failures/F95.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>F95: Failure of Success Criterion 1.4.13 due to content shown on hover not being hoverable | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/failures/F96.html
+++ b/techniques/failures/F96.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>F96: Failure due to the accessible name not containing the visible label text | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/failures/F97.html
+++ b/techniques/failures/F97.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>F97: Failure due to locking the orientation to landscape or portrait view | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/failures/F98.html
+++ b/techniques/failures/F98.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>F98: Failure due to interactions being limited to touch-only on touchscreen devices | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/failures/F99.html
+++ b/techniques/failures/F99.html
@@ -2,7 +2,6 @@
 <meta charset="UTF-8">
 <title>F99: Failure of Success Criterion 2.1.4 due to implementing character key shortcuts that cannot be turned off or
     remapped | WAI | W3C</title>
-  <link rel="stylesheet" type="text/css" href="../../css/editors.css">
 
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/general/G207.html
+++ b/techniques/general/G207.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>G207: Ensuring that a contrast ratio of 3:1 is provided for icons | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/general/G208.html
+++ b/techniques/general/G208.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>G208: Including the text of the visible label as part of the accessible name | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 		<style>
 		.accessibly-hidden {position:absolute;
 			left:-10000px;

--- a/techniques/general/G209.html
+++ b/techniques/general/G209.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>G209: Provide sufficient contrast at the boundaries between adjoining colors | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/general/G210.html
+++ b/techniques/general/G210.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>G210: Ensuring that drag-and-drop actions can be cancelled | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/general/G211.html
+++ b/techniques/general/G211.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>G211: Matching the accessible name to the visible label | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/general/G212.html
+++ b/techniques/general/G212.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>G212: Using native controls to ensure  functionality is triggered on the up-event. | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/general/G213.html
+++ b/techniques/general/G213.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>G213: Provide conventional controls and an application setting for motion activated input | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/general/G215.html
+++ b/techniques/general/G215.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>G215: Providing controls to achieve the same result as path based or multipoint gestures | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/general/G216.html
+++ b/techniques/general/G216.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>G216: Providing single point activation for a control slider | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/general/G217.html
+++ b/techniques/general/G217.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
 <meta charset="UTF-8">
 <title>G217: Providing a mechanism to allow users to remap or turn off character key shortcuts | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/general/G218.html
+++ b/techniques/general/G218.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="ja"><head>
 <meta charset="UTF-8">
 <title>G218: 電子メールリンクによる認証 | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/general/G219.html
+++ b/techniques/general/G219.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="ja"><head>
 <meta charset="UTF-8">
 <title>G219: コンテンツを操作するドラッグ動作の代替手段を利用可能にする | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/general/G220.html
+++ b/techniques/general/G220.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="ja"><head>
 <meta charset="UTF-8">
 <title>G220: 問い合わせリンクを一貫した場所に提供する | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/general/G221.html
+++ b/techniques/general/G221.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="ja"><head>
 <meta charset="UTF-8">
 <title>G221: プロセスの以前のステップからデータを提供する | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/html/H100.html
+++ b/techniques/html/H100.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="ja"><head>
 <meta charset="UTF-8">
 <title>H100: 適切にマークアップされた電子メール及びパスワードの入力を提供する | WAI | W3C</title>
-    <link rel="stylesheet" type="text/css" href="../../css/editors.css">
   
 
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/techniques/html/H99.html
+++ b/techniques/html/H99.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="ja"><head>
 <meta charset="UTF-8">
 <title>H99: ページ選択メカニズムを提供する | WAI | W3C</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css">
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
いくつかのテクニックに以下のようなCSSの参照が含まれているが、

```
<link rel="stylesheet" type="text/css" href="../../css/editors.css">
```

これがNot Foundとなっている。

本家の方でもこのCSSはNot Foundになっており、消し忘れである可能性が高いと判断したため、一括で削除することとした。