### PR TITLE
G211の翻訳

### DIFF
--- a/techniques/general/G211.html
+++ b/techniques/general/G211.html
@@ -1,6 +1,6 @@
-<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="ja"><head>
 <meta charset="UTF-8">
-<title>G211: Matching the accessible name to the visible label | WAI | W3C</title>
+<title>G211: アクセシブルな名前 (accessible name) を視覚的なラベルと一致させる | WAI | W3C</title>
 	
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -10,8 +10,6 @@
 
 
 
-<!-- 日本語訳されるまでの一時的なスクリプト -->
-<script src="../untranslated-note.js"></script>
 </head>
 	<body dir="ltr">
 
@@ -19,12 +17,12 @@
 <div class="minimal-header-container default-grid">
   <header class="minimal-header" id="site-header">
     <div class="minimal-header-name">
-      <a href="https://w3c.github.io/wcag/techniques/">WCAG 2.2 Techniques</a>
+      <a href="https://waic.jp/translations/WCAG22/Techniques/">WCAG 2.2 テクニック集</a>
     </div>
     
       <div class="minimal-header-subtitle">Examples of ways to meet WCAG; not required</div>
     
-    <a class="minimal-header-link" href="https://w3c.github.io/wcag/techniques/about">About WCAG Techniques</a>
+    <a class="minimal-header-link" href="https://waic.jp/translations/WCAG22/Techniques/about">WCAG テクニック集について</a>
     <div class="minimal-header-logo">
       <a href="http://w3.org/" aria-label="W3C">
         <svg xmlns="http://www.w3.org/2000/svg" height="2em" viewBox="0 0 91.968 44">
@@ -53,45 +51,43 @@
 
 <div class="default-grid with-gap leftcol">
 <aside class="box nav-hack sidebar standalone-resource__sidebar">
-    <header class="box-h">Page Contents</header>
+    <header class="box-h">このページの内容</header>
     <div class="box-i">
       <nav aria-label="page contents" class="navtoc">
-        <ul><li><a href="#technique">About this Technique</a></li>
-<li><a href="#description">Description</a></li>
-<li><a href="#examples">Examples</a></li>
-<li><a href="#resources">Related Resources</a></li>
-<li><a href="#related">Related Techniques</a></li>
-<li><a href="#tests">Tests</a></li>
+        <ul><li><a href="#technique">このテクニックについて</a></li>
+<li><a href="#description">解説</a></li>
+<li><a href="#examples">事例</a></li>
+<li><a href="#resources">関連リソース</a></li>
+<li><a href="#related">関連テクニック</a></li>
+<li><a href="#tests">検証</a></li>
 </ul>
       </nav>
     </div>
 </aside>
 
 <main id="main" class="standalone-resource__main">
-<!-- 日本語訳されるまでの一時的な注記 -->
-<div class="untranslated-note"><p>このWCAG 2.2 テクニック集の日本語訳は作業中となっています。WCAG 2.1 達成方法集の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Techniques/">WCAG 2.1 達成方法集</a> ]</p></div>
 		
-<h1><span>Technique G211:</span>Matching the accessible name to the visible label</h1>
+<h1><span>テクニック G211:</span>アクセシブルな名前 (accessible name) を視覚的なラベルと一致させる</h1>
 
 
 
 
 <section id="technique" class="box">
-	<h2 class="box-h box-h-icon">About this Technique</h2>
+	<h2 class="box-h box-h-icon">このテクニックについて</h2>
 	<div class="box-i">
 
 
   
   <p>
-    This technique relates to
+    このテクニックは
     
-<a href="https://w3c.github.io/wcag/understanding/label-in-name">2.5.3: Label in Name</a>
-(<strong>Sufficient</strong>).</p>
+<a href="https://waic.jp/translations/WCAG22/Understanding/label-in-name">2.5.3: ラベルを含む名前 (name)</a>
+(<strong>十分なテクニック</strong>) に関連する。</p>
   
 
 
 
-  <p>This technique applies to all web technologies that include interactive controls (such as links or form inputs).</p>
+  <p>このテクニックは、インタラクティブなコントロール (リンク、フォーム入力など) を含む全てのウェブ技術に適用される。</p>
 
 </div>
 </section>
@@ -101,61 +97,62 @@
 		
 		
 		<section id="description">
-			<h2>Description</h2>
-			<p>The objective of this technique is to ensure that speech input users can operate web content reliably while not adversely affecting other users of assistive technology.</p>
-			<p>When speech input users interact with a web page, they usually speak a command followed by the reference to some visible label (such as text beside an input field or inside a button or link). For example, they may say "click search" to activate a button labelled Search. When speech recognition software processes speech input and looks for matches, it uses the <a href="https://www.w3.org/TR/accname/"> accessible name</a> of controls. Where there is a mismatch between the text in the label and the text in the accessible name, it can cause issues for the user. The simplest way to enable speech input users and meet 2.5.3 Label in Name is to ensure that the accessible name matches the visible text label.</p>
-			<h3>Determining the appropriate label</h3>
-			<p>Sometimes more than one text string will be positioned in the vicinity of a control that could be considered a candidate for its label. For example, a set of inputs that each have their own labels may also be preceded by a heading, an instruction or a group label (such as an HTML legend/fieldset or an ARIA group or radiogroup). Note that the term "group label" means something different than "label", both programmatically and in regard to 2.5.3 Label in Name.</p>
-			<p>The <a href="https://w3c.github.io/wcag/understanding/label-in-name">Understanding 2.5.3 Label in Name document</a> recommends that only the text string adjacent to or in close proximity to an input should be treated as the label when assessing a control's label for the purposes of meeting 2.5.3 (see the section "Identifying label text for components"). There are both practical and technical reasons for restricting the designation of an input's label in this way. The technical reasons are discussed in the Understanding document's section called Accessible Name and Description Computation specification.</p>
+			<h2>解説</h2>
+			<p>このテクニックの目的は、音声入力の利用者が支援技術の他の利用者に悪影響を与えることなく、ウェブコンテンツを確実に操作できるようにすることである。</p>
+			<p>音声入力を行う利用者がウェブページを操作するとき、通常利用者はコマンドを発話し、続いていくつかの可視ラベルを参照する (入力欄の隣又はボタンもしくはリンクの中にあるテキストなど)。例えば、利用者は検索とラベル付けされたボタンを実行するために「クリック　検索」と発話するかもしれない。音声認識ソフトウェアが音声入力を処理して一致する内容を探すとき、音声認識ソフトウェアはコントロールの<a href="https://www.w3.org/TR/accname/">アクセシブルな名前 (accessible name)</a> を使用する。ラベルのテキストとアクセシブルな名前 (accessible name) のテキストとの間に不一致があると、利用者に問題を引き起こすことがある。音声入力の利用者を使用可能にし、2.5.3 ラベルを含む名前 (name) を満たす最も簡単な方法は、アクセシブルな名前 (accessible name) が可視のテキストラベルとの一致を確実にすることである。</p>
+			<h3>適切なラベルの決定</h3>
+			<p>時には、ラベル候補と見なされうる複数のテキスト文字列がコントロール付近に配置されることがある。例えば、それぞれ独自のラベルを持った一連の入力の前に見出し、説明又はグループラベル (HTML の legend/fieldset、ARIA group、radiogroup など) もあるかもしれない。「グループラベル」という用語は、プログラム上及び 2.5.3 ラベルを含む名前 (name) に関した両方において「ラベル」とは異なる意味を持つことに注意すること。</p>
+			<p><a href="https://waic.jp/translations/wcag22/Understanding/label-in-name">2.5.3 ラベルを含む名前 (name) の解説書</a>は、2.5.3 を満たす目的としてコントロールのラベルを評価する場合、入力に隣接又は近接したテキスト文字列のみがラベルとして扱われるべきことを推奨している (「コンポーネントのラベルテキストを特定する」セクションを参照すること)。このように入力のラベルの指定を制限する実質的かつ技術的な理由がある。技術的な理由は、解説書の Accessible Name and Description Computation 仕様というセクションで議論されている。</p>
 			
 		</section>
 		<section id="examples">
-			<h2>Examples</h2>
+			<h2>事例</h2>
 			
-<p>Mapping a visible label to the accessible name is achieved in many technologies by meeting <a href="https://w3c.github.io/wcag/understanding/info-and-relationships.html"> 1.3.1 Information and Relationships</a> through the proper use of native semantics. Many controls derive accessible names by correct nesting of elements, while other elements have specific attributes which are a valid means of providing or referencing an accessible name.</p>
-			<p>The accessible name should be assigned through native elements and semantics where possible. That helps ensure an exact match between the visible label and name.</p>
+<p>可視ラベルのアクセシブルな名前 (accessible name) へのマッピングは、ネイティブセマンティクスを正しく使用し <a href="https://waic.jp/translations/WCAG22/Understanding/info-and-relationships.html">1.3.1 情報及び関係性</a>を満たすことで、多くの技術で達成できる。多くのコントロールは正しい要素の入れ子からアクセシブルな名前 (accessible name) を得る一方、他の要素はアクセシブルな名前 (accessible name) を参照する又は提供する有効な方法である特定の属性を持つ。</p>
+			<p>アクセシブルな名前 (accessible name) は、可能な場合、ネイティブ要素やセマンティクスで割り当てられるべきである。それにより、可視ラベルと名前が完全に一致することを保証する助けになる。</p>
 			<section class="example" id="example-1-anchor-text-provides-both-the-link's-label-and-its-accessible-name">
-			<h3>Example 1: Anchor text provides both the link's label and its accessible name</h3>
-			<p id="linksample">Using conventional HTML, the text between the <code class="language-html">a</code> element's tags provides both the link's visible text and the accessible name "Code of conduct":</p>		
+			<h3>事例 1: アンカーテキストがリンクのラベルとそのアクセシブルな名前 (accessible name) の両方を提供している</h3>
+			<p id="linksample">標準の HTML を使用し、<code class="language-html">a</code>  要素のタグ間のテキストが「Code of conduct」というリンクの可視テキストとアクセシブルな名前 (accessible name) の両方を提供している：</p>		
 			<code class="language-html">&lt;p&gt;Go to our &lt;a href="url-to-page-about-code.html"&gt;Code of conduct&lt;/a&gt;&lt;/p&gt;</code>
 				<section id="non-working-sample-of-anchor">
-			<h4>Non-working sample of anchor</h4>
+			<h4>アンカーの動作しないサンプル</h4>
 			<p>Go to our <a href="#linksample">Code of conduct</a></p>
 				</section>
 			</section>
 				<section class="example" id="example-2-text-in-label-element-provides-name-for-input-via-for-attribute">
 
-		<h3>Example 2: Text in <code class="language-html">label</code> element provides name for input via <code class="language-html">for</code> attribute</h3>
-		<p>The text between the <code class="language-html">label</code> tags also serves as the checkbox input's accessible name "Notify me of delays" by using the <code class="language-html">for</code> attribute which references the <code class="language-html">id</code> of the <code class="language-html">input</code>.</p>	
+		<h3>事例 2: <code class="language-html">label</code> 要素内のテキストは <code class="language-html">for</code> 属性を通じて入力の名前を提供している</h3>
+		<p><code class="language-html">label</code> タグ間のテキストは、<code class="language-html">for</code> 属性を使用し、<code class="language-html">input</code> の <code class="language-html">id</code> を参照することでチェックボックス入力のアクセシブルな名前 (accessible name)「Notify me of delays」としても機能する。</p>	
 <pre><code class="language-html">&lt;input type="checkbox" id="notification" name="notify" value="delays"&gt;
 &lt;label for="notification"&gt;Notify me of delays&lt;/label&gt;
 </code></pre>
       <section id="working-sample-of-input">
-      	<h4>Working sample of input</h4>
+      	<h4>入力の動作するサンプル</h4>
       	<input type="checkbox" id="notification" name="notify" value="delays">
   <label for="notification">Notify me of delays</label>
       </section>
 	</section>	
 		<section class="example" id="example-3-the-button-text-provides-the-accessible-name">			
-		<h3>Example 3: The button text provides the accessible name</h3>
+		<h3>事例 3: ボタンテキストがアクセシブルな名前 (accessible name) を提供している</h3>
 
-		<p>The text inside a <code class="language-html">button</code> element becomes both its visible label and its accessible name:</p>	
+		<p><code class="language-html">button</code> 要素内のテキストは可視ラベルとそのアクセシブルな名前 (accessible name) の両方になる:</p>	
 		<code class="language-html">&lt;button&gt;Send&lt;/button&gt;</code>
     <section id="non-working-sample-of-button">
-  		<h4>Non-working sample of button</h4>
+  		<h4>ボタンの動作しないサンプル</h4>
   		<button type="button">Send</button>
     </section>
 	</section>	
 			
 			<section class="example" id="example-4-simple-radio-button-group">
-				<h3>Example 4: Simple Radio Button Group</h3>
-				<p>Radio buttons typically appear in a group, where each button is labelled and the group of buttons is preceded by information which explains or categorizes the group.</p>
+				<h3>事例 4: シンプルなラジオボタンのグループ</h3>
+				<p>通常、ラジオボタンはグループで表示される。各ボタンはラベル付けされ、ボタングループの前には、グループを説明又はカテゴライズする情報が置かれる。</p>
 				<figure id="figure-call-me-radio-button-group">
 					<img src="img/call-me-radio-button-group.png" alt="Call me when balance exceeds $10,000, Yes No">
-					<figcaption>Figure 1 "Call me when balance exceeds $10,000 radio group, with Yes and No choices</figcaption>
+					<figcaption>図 1 Yes 及び No という選択肢の Call me when balance exceeds $10,000 ラジオグループ</figcaption>
 				</figure>
-				<p>The label for each component should be restricted to "Yes" and "No". To meet <a href="https://w3c.github.io/wcag/understanding/info-and-relationships"> 1.3.1 Information and Relationships</a> and <a href="https://w3c.github.io/wcag/understanding/labels-or-instructions.html"> 3.3.2 Labels or Instructions</a>, the "Call me…" text can be coded to convey the relationship to ATs, in this example by using a <code>fieldset</code> and <code>legend</code>.</p>
-				<p>If the label is not restricted to the string adjacent to the radio button, multiple interpretations of what constitutes the label can result in less uniform functionality. If "Yes" alone is not the label for the first radio button, is it "Call me when balance exceeds $10,000"? Or is it a combination of text strings, in which case is the order "Call me when balance exceeds $10,000 Yes" or "Yes, Call me when balance exceeds $10,000"? Decisions to combine text strings can have negative effects on screen reader users since the order of concatenation can affect meaning. In this example, "No, call me when balance exceeds $10,000" could be very confusing to a screen reader user.</p>
+				<p>各コンポーネントのラベルは "Yes" 及び "No" に制限すべきである。<a href="https://waic.jp/translations/WCAG22/Understanding/info-and-relationships">1.3.1 情報及び関係性</a>及び <a href="https://waic.jp/translations/WCAG22/Understanding/labels-or-instructions.html">3.3.2 ラベル又は説明</a>を満たすには、"Call me-" と書かれたテキストは支援技術に関係性を伝えるためにコーディングでき、この例では <code>fieldset</code> 及び <code>legend</code> を用いている。</p>
+				<p>ラベルがラジオボタンに隣接している文字列に制限されていない場合、何がラベルを構成するかという複数の解釈は、より統一されていない機能をもたらす。"Yes" だけが最初のラジオボタンのラベルではない場合、"Call me when balance exceeds $10,000" がそうだろうか？　もしくは、テキスト文字列の組み合わせだろうか？　その場合、順序は "Call me when balance exceeds $10,000 Yes" 又は "Yes, Call me when balance exceeds $10,000" だろうか？　テキスト文字列を組み合わせる選択は、連結の順序が意味に影響するため、スクリーンリーダーの利用者に悪影響を与えることがある。この例では、"No, call me when balance exceeds $10,000" はスクリーン・リーダーの利用者にとってとても
+わかりにくい可能性がある。</p>
 				<code>
 					&lt;fieldset&gt;<br>
 					&lt;legend&gt;Call me when balance exceeds $10,000?&lt;/legend&gt;&lt;br /&gt;<br>
@@ -165,37 +162,37 @@
 					&lt;label for="no"&gt;No&lt;/label&gt;<br>
 				&lt;/fieldset&gt;<br>
 			</code>
-				<p class="working-example"><a href="../../working-examples/label-in-name-general/example1.html">Working example of Simple Radio Button Group</a></p>
+				<p class="working-example"><a href="https://www.w3.org/WAI/WCAG22/working-examples/label-in-name-general/example1.html">シンプルなラジオボタングループの動作例</a></p>
 			</section>
 			<section class="example" id="example-5-checkbox-groupings">
-				<h3>Example 5: Checkbox Groupings</h3>
-				<p>For checkbox groupings, implementations that attempt to incorporate more than just the immediate checkbox label into the accessible name can also be problematic if not isolated to the adjacent text string.</p>
+				<h3>事例 5: チェックボックスのグループ化</h3>
+				<p>チェックボックスのグループ化では、単に直近のチェックボックスラベル以上のものをアクセシブルな名前 (accessible name) に組みこもうとする実装も、隣接したテキスト文字列に切り離されていない限り、問題になる可能性がある。</p>
 				<figure id="figure-value-checkbox">
 					<img src="img/value-checkbox.png" alt="What do you value in our service? (Check all that apply) Courtesy, Promptness, Store Hours, Knowledge">
-					<figcaption>Figure 2 What do you value in our service? checkbox group, with 4 choices.</figcaption>
+					<figcaption>図 2 四つの選択肢がある What do you value in our service? チェックボックスグループ。</figcaption>
 				</figure>
 				
-				<p>In Figure 2, there is a long text string that combines a group label and instruction, "What do you value in our service (check all that apply)?" Each of the checkboxes also has its own one- or two-word label. In regard to 2.5.3, the labels for the components should be restricted to "Courtesy", "Promptness", "Store Hours" and "Knowledge".</p>
-				<p>Attempting to include the preceding text as part of the accessible name can potentially make it more difficult to isolate a control by spoken commands for speech-input users. Such a construction will also negatively increase verbosity for screen reader users (with the combined text strings read out for each of the inputs before the input's state). The simplest solution is to restrict the accessible name to the text immediately beside the checkboxes, using similar techniques to those for the standard radio button group.</p>
+				<p>図 2 内には、グループラベルと指示を組み合わせた長いテキスト文字列 "What do you value in our service (check all that apply)?" がある。各チェックボックスにはそれ自身の一語又は二語のラベルも持っている。2.5.3 に関して、コンポーネントのラベルは "Courtesy"、"Promptness"、"Store Hours" 及び "Knowledge" に限られるべきである。</p>
+				<p>前述のテキストをアクセシブルな名前 (accessible name) の一部に含めようとすると、発話入力の利用者に発話コマンドでコントロールを分離することをより難しくさせる可能性がある。そのような構造はまた、スクリーンリーダーの利用者に対して、(入力状態の前に各入力の組み合わされたテキスト文字列が読み上げられ) 好ましくない冗長性を増やす。もっとも単純な解決方法は、標準的なラジオボタングループと同様のテクニックを使用し、チェックボックスのすぐ隣にあるテキストのみにアクセシブルな名前 (accessible name) を制限することである。</p>
 		</section>
 					<section class="example" id="example-6-stacked-labels">
-				<h3>Example 6: Stacked Labels</h3>
-				<p>Although labels for comboboxes, dropdown lists, text inputs, and other widgets are typically oriented immediately to the left of the component, there is an alternative established convention where labels are stacked above the inputs, aligned with their left edge.
+				<h3>事例 6: 積み重ねられたラベル</h3>
+				<p>コンボボックス、ドロップダウンリスト、テキスト入力、及び他のウィジェットのラベルは通常コンポーネントのすぐ左に配置されるが、入力の上にラベルが積み重ねられる場合に、左端でそろえられることが代替の確立された慣例となっている。
 				</p>
 				<figure id="figure-stacked-label">
 
-					<img src="img/stacked-label.png" alt="two inputs labelled Email and Password" height="136" width="224">
+					<img src="img/stacked-label.png" alt="Email 及び Password とラベル付けされた二つの入力" height="136" width="224">
 
-					<figcaption>Figure 3 Two inputs with the labels positioned above and to the left.</figcaption>
+					<figcaption>図 3 上部及び左に配置されたラベルを持つ二つの入力</figcaption>
 				</figure>
 				
-				<p>In Figure 3, the inputs are stacked and left-aligned, with the labels immediately preceding each input, also left-aligned. There is additional white space between the label and the preceding input so that the label is closest to its associated text input. Stacked labels are relatively common in mobile designs, where horizontal space is constrained.</p>
-				<p>Figure 4 shows a variation on stacked labels, where hints and guidance are included between the label and the input. This design does not provide an adjacent label. However, the "New Password" label is still considered to be in close enough proximity, especially given its size and boldness relative to the smaller and lower-contrast guidance text. The associations are reinforced programmatically, where the hint text is given a role of <code class="language-html">aria-describedby</code> and the label is properly associated with the input.</p>
+				<p>図 3 では、入力が積み重ねられて左揃えにされており、ラベルもまた各入力の直前で左揃えになっている。ラベルが関連したテキスト入力と最も近くなるよう、ラベルとその前の入力の間には追加の空白がある。横方向の余白が限られているモバイルデザインでは、積み重ねられたラベルは比較的一般的である。</p>
+				<p>図 4 はヒント及び助言がラベルと入力の間に含まれた、積み重ねられたラベルの変化形を表している。このデザインでは、隣接したラベルを提供していない。ただし、"New Password" というラベルは、特により小さくコントラストの低い助言テキストに比べて、そのサイズ及び太さを考慮すると、依然として十分近接していると考えられる。この関連づけは、<code class="language-html">aria-describedby</code> というロールがヒントテキストに与えられ、かつ入力がラベルと適切に関連づけられている場合、プログラムにより強化される。</p>
 								<figure id="figure-new-password">
 					<img src="img/new-password.png" alt="New Password. Passwords must be 10 or more characters, and contain at least one capital, numeric and non-alphanumeric.'">
-					<figcaption>Figure 4 New Password label positioned above input with a smaller-point text string about the password requirements positioned between the large label and the input.</figcaption>
+					<figcaption>図 4 New Password というラベルが入力の上に配置され、パスワード要件についてのサイズの小さいテキスト文字列は大きいラベルと入力の間に配置されている。</figcaption>
 				</figure>
-				<p>The hint text in such implementations should be kept to a single line where possible, since accessibility issues can arise where a more lengthy hint separates the label from its input. Figure 4 illustrates that the concept of "adjacent text" is a guide for label interpretation, but cannot always serve as a hard rule.</p>
+				<p>より長いヒントが入力からラベルを分離する場合、アクセシビリティの問題が発生する可能性があるため、そのような実装のヒントテキストは可能であれば一行にとどめるべきである。図 4 は、「隣接しているテキスト」という概念はラベル解釈の助言であることを説明するが、常に厳格なルールとして機能するわけではない。</p>
 				<code>
 				&lt;form&gt;<br>
 			&lt;label class="label" for="example-2"&gt;<br>
@@ -207,19 +204,19 @@
 			&lt;input class="input" id="example-2" name="example-2" type="text" aria-describedby="example-2-hint"&gt;<br>
 		&lt;/form&gt;<br>
 	</code>
-				<p class="working-example"><a href="../../working-examples/label-in-name-general/example2.html">Working example of stacked labels</a></p>
+				<p class="working-example"><a href="https://www.w3.org/WAI/WCAG22/working-examples/label-in-name-general/example2.html">積み重ねられたラベルの動作する例</a></p>
 
 		</section>
 
 					<section class="example" id="example-7-range-of-inputs-with-few-labels">
-				<h3>Example 7: Range of inputs with few labels</h3>
-				<p>A less common disparity between labels and inputs can occur when a group of radio buttons is set up to elicit a choice across a range. The labels may only be located at each end of the range or may be interspersed at various points in the range.</p>
+				<h3>事例 7: 範囲の入力及びわずかなラベル</h3>
+				<p>ラベルと入力との間のあまり一般的ではない不均衡は、ラジオボタンのグループが範囲にわたった選択を引き出すよう設定されている場合に発生することがある。ラベルは範囲の両端に配置されるかもしれない、又は範囲のさまざまな場所に散っているかもしれない。</p>
 				<figure id="figure-rate-response">
 					<img src="img/rate-response.png" alt="Rate your response, Hated it, Loved it">
-					<figcaption>Figure 6 Line of 5 radio buttons with Hated it and Loved it labels at each end</figcaption>
+					<figcaption>図 6 Hated it と Loved it というラベルが両端にある五つのラジオボタンの行</figcaption>
 				</figure>
 				
-				<p>The two labels, "Hated it" and "Loved it", are adjacent to the first and last radio buttons, and should be their accessible names. Speech-input users can speak either of these labels to select a radio button, and then use arrow navigation (e.g., "Press right arrow") to modify the selection. "Rate your response" is the text describing the whole widget and can be associated as the group label (here using <code class="language-html">legend</code>). The three middle radio buttons do not have visible labels. In the code example they are given title attributes of "Disliked", "So-so" and "Liked" in order to meet 3.3.2 Labels or Instructions.</p>
+				<p>"Hated it" 及び "Loved it" の二つのラベルは、最初及び最後のラジオボタンに隣接しており、かつそれらのアクセシブルな名前 (accessible name) であるべきである。音声入力の利用者はこれらのいずれかのラベルを発話することでラジオボタンを選択し、矢印操作を使用して選択を変更できる (例「右矢印を押す」)。"Rate your response" はウィジェット全体を説明するテキストであり、(ここで <code class="language-html">legend</code> を使用することで) グループラベルとして関連付けられる。三つの中央のラジオボタンは可視のラベルを持たない。コード例では、3.3.2 ラベル又は説明を満たすために "Disliked"、"So-so" 及び "Liked" という title 属性を与えられている。</p>
 				<pre><code class="language-html">&lt;fieldset&gt;
   &lt;legend&gt;Rate your response&lt;/legend&gt;
   &lt;label for="hated"&gt;Hated it&lt;/label&gt;
@@ -231,13 +228,13 @@
   &lt;label for="loved"&gt;Loved it&lt;/label&gt;
 &lt;/fieldset&gt;
 </code></pre>
-				<p class="working-example"><a href="../../working-examples/label-in-name-general/example4.html">Working example of range of inputs</a></p>
+				<p class="working-example"><a href="https://www.w3.org/WAI/WCAG22/working-examples/label-in-name-general/example4.html">入力の範囲の動作例</a></p>
 		</section>
 	
 		<section class="example" id="example-8-text-in-parentheses-and-punctuation">
-			<h3>Example 8: Text in parentheses and punctuation</h3>
-			<p>Technique G211 is not intended to complicate existing conventions for the construction of accessible form inputs. As described in the <em>Punctuation and capitalization</em> and <em>Text in parentheses</em> subsections of the Understanding document, information does not always need to be included in the accessible name in an attempt to meet the Label in Name requirement, especially where the text would not normally be spoken when using speech recognition to navigate to controls. Where there are established ways of ensuring information and relationships conveyed visually are present programmatically, it is acceptable to leave text in parentheses and punctuation out of the accessible name.</p>
-			<p>The following snippet demonstrates possible techniques mentioned in the Understanding document. Since the required field is programmatically indicated, and the input restrictions on the date are surfaced through <code class="language-html">aria-describedby</code>, the asterisk and parenthetical information has been left out of the accessible name.</p>
+			<h3>事例 8: 括弧内のテキスト及び句読点</h3>
+			<p>テクニック G211は、アクセシブルなフォーム入力の構築に関する既存の慣例を複雑にすることを意図したものではないありません。解説書の<em>句読点及び大文字の使用</em>及び<em>括弧内のテキスト</em>のサブセクションで説明されているように、ラベルを含む名前 (name) 要件を満たすために、アクセシブルな名前 (accessible name) に必ずしも情報を含める必要はない。特に、音声認識を使用してコントロールに移動する際にテキストが通常読み上げられない場合はなおさらである。視覚的に伝えられる情報及び関係性がプログラムによって確実に提示される方法が確立されている場合は、括弧内のテキストと句読点をアクセシブルな名前 (accessible name) から除外しても問題ない。</p>
+			<p>次のスニペットは、解説書に記載されている可能なテクニックを示している。必須フィールドはプログラムによって示されており、日付の入力制限は <code class="language-html">aria-describedby</code> によって表示されるため、アスタリスクと括弧内の情報はアクセシブルな名前 (accessible name) から除外されている。</p>
 
 <pre><code class="language-html">
 &lt;label for="name"&gt;Name&lt;/label&gt; *
@@ -246,7 +243,7 @@
 &lt;input type="text" name="birth" id="birth" aria-describedby="mask"&gt;</code></pre>
 
 <section id="working-sample-of-inputs-with-simplified-accessible-names">
-	<h4>Working sample of inputs with simplified accessible names</h4>
+	<h4>簡略化されたアクセシブルな名前の入力の動作サンプル</h4>
 
 
 <div><label for="name">Name</label> *</div>
@@ -268,15 +265,15 @@
 &lt;/fieldset&gt;<br>
 </code>
 </p>
-				<p class="working-example"><a href="../../working-examples/label-in-name-general/example4.html">Working example of range of inputs</a></p>
+				<p class="working-example"><a href="https://www.w3.org/WAI/WCAG22/working-examples/label-in-name-general/example4.html">入力の範囲の動作例</a></p>
 
 		</section>
 	</section>
 		
 		
 		<section id="resources">
-			<h2>Related Resources</h2>
-<p style="margin-bottom: 1.5em;"><em><small>No endorsement implied.</small></em></p>
+			<h2>関連リソース</h2>
+<p style="margin-bottom: 1.5em;"><em><small>推奨を意味するものではない。</small></em></p>
 
 
 			<ul>
@@ -288,7 +285,7 @@
 
 
 <section id="related">
-			<h2>Related Techniques</h2>
+			<h2>関連テクニック</h2>
 			<ul>
 				<li><a href="../html/H44">H44: Using label elements to associate text labels with form controls</a></li>
 				<li><a href="../html/H71">H71: Providing a description for groups of form controls using fieldset and legend elements</a></li>
@@ -297,19 +294,19 @@
 			</ul>
 		</section>
 <section id="tests">
-			<h2>Tests</h2>
+			<h2>検証</h2>
 			<section class="test-procedure" id="procedure">
-				<h3>Procedure</h3>
+				<h3>手順</h3>
 				<ol>
-					<li>For input controls, examine each input that has adjacent text which serves as its label</li>
-					<li>For each input, check that the label's entire string of text (optionally disregarding letter case, punctuation, and information in parentheses) matches the accessible name for the input, according to the accessible name computation</li>
-			<li>For buttons, links, menus and other non-input controls, examine each control that contains text which serves as its label</li>
-						<li>For each non-input control, check that the label's entire string of text (optionally disregarding letter case, punctuation and information in parentheses) matches the accessible name for the input</li></ol>
+					<li>入力コントロール対して、ラベルとして機能する隣接テキストを持つ各入力を調べる</li>
+					<li>各入力について、ラベルのテキスト文字列全体 (大文字と小文字、句読点、括弧内の情報はオプションで無視) が、入力のアクセシブルな名前 (accessible name) と一致するかどうかを、アクセシブルな名前 (accessible name) の計算に従ってチェックする</li>
+			<li>ボタン、リンク、メニュー及びその他の非入力コントロールに対して、そのラベルとして機能するテキストを含む各コントロールを調べる</li>
+						<li>入力以外のコントロールごとに、ラベルのテキスト文字列全体 (大文字と小文字、句読点、括弧内の情報はオプションで無視) が入力のアクセシブルな名前 (accessible name) と一致することをチェックする</li></ol>
 			</section>
 			<section class="test-results" id="expected-results">
-				<h3>Expected Results</h3>
+				<h3>期待される結果</h3>
 				<ul>
-					<li>Checks #2 and #4 are true.</li>
+					<li>チェック 2 及び 4 が真である。</li>
 				</ul>
 			</section>
 		</section>
@@ -329,14 +326,13 @@
     <svg focusable="false" aria-hidden="true" class="icon-comments" viewBox="0 0 28 28">
       <path d="M22 12c0 4.422-4.922 8-11 8-0.953 0-1.875-0.094-2.75-0.25-1.297 0.922-2.766 1.594-4.344 2-0.422 0.109-0.875 0.187-1.344 0.25h-0.047c-0.234 0-0.453-0.187-0.5-0.453v0c-0.063-0.297 0.141-0.484 0.313-0.688 0.609-0.688 1.297-1.297 1.828-2.594-2.531-1.469-4.156-3.734-4.156-6.266 0-4.422 4.922-8 11-8s11 3.578 11 8zM28 16c0 2.547-1.625 4.797-4.156 6.266 0.531 1.297 1.219 1.906 1.828 2.594 0.172 0.203 0.375 0.391 0.313 0.688v0c-0.063 0.281-0.297 0.484-0.547 0.453-0.469-0.063-0.922-0.141-1.344-0.25-1.578-0.406-3.047-1.078-4.344-2-0.875 0.156-1.797 0.25-2.75 0.25-2.828 0-5.422-0.781-7.375-2.063 0.453 0.031 0.922 0.063 1.375 0.063 3.359 0 6.531-0.969 8.953-2.719 2.609-1.906 4.047-4.484 4.047-7.281 0-0.812-0.125-1.609-0.359-2.375 2.641 1.453 4.359 3.766 4.359 6.375z"></path>
     </svg>
-    <h2>Help improve this page</h2>
+    <h2>このページを改善する</h2>
   </header>
   <div class="box-i">
-  <p>Please share your ideas, suggestions, or comments via e-mail to the publicly-archived list <a href="mailto:public-agwg-comments@w3.org?subject=%5BUnderstanding%20and%20Techniques%20Feedback%5D">public-agwg-comments@w3.org</a> or via GitHub</p>
+  <p>あなたのアイデア、提案、又はコメントを、Google フォーム 又は GitHub で共有してください。</p>
     <div class="button-group">
-      <a href="mailto:public-agwg-comments@w3.org?subject=%5BUnderstanding%20and%20Techniques%20Feedback%5D" class="button"><span>E-mail</span></a>
-      <a href="https://github.com/w3c/wcag/issues/" class="button"><span>Fork &amp; Edit on GitHub</span></a>
-      <a href="https://github.com/w3c/wcag/issues/new" class="button"><span>New GitHub Issue</span></a>
+      <a class="button" href="https://docs.google.com/forms/d/e/1FAIpQLSdIpvogLx8kGIMewhQ6MzhG2pOCQZ50iIBViGg8pUrRJuslKg/viewform?entry.685195438=https%3A%2F%2Fwaic.jp%2Ftranslations%2FWCAG22%2FUnderstanding%2Ffocus-not-obscured-minimum" id="file-issue">翻訳に関するお問い合わせ (Google フォーム)</a>
+      <a href="https://github.com/waic/wcag22/" class="button"><span>GitHub</span></a>
     </div>
   </div>
 </aside>
@@ -358,12 +354,15 @@
       <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide</a> project,
       co-funded by the European Commission.
     </p>
+    <p>この文書は、2025 年 5 月 21 日付けの <a href="https://w3c.github.io/wcag/techniques/">Techniques for WCAG 2.2</a> を、<a href="https://waic.jp/">ウェブアクセシビリティ基盤委員会 (WAIC)</a> の翻訳ワーキンググループが翻訳して公開しているものです。この文書の正式版は、W3C のサイトにある英語版です。正確な内容については、W3C が公開している原文 (英語) をご確認ください。この翻訳文書は作業進行中です。また、あくまで参考情報であり、翻訳上の誤りが含まれていることがあります。
+    </p>
+    <p>この翻訳文書の利用条件については、<a href="https://waic.jp/license-for-translated-documents/">WAICが提供する翻訳文書のライセンス</a>をご覧ください。</p>
   </div>
 </footer>
 
 <footer class="site-footer grid-4q" aria-label="Site">
   <div class="q1-start q3-end about">
-    <div>
+    <!--div>
       <p><a class="largelink" href="https://www.w3.org/WAI/" dir="auto" translate="no" lang="en">W3C Web Accessibility Initiative (WAI)</a></p>
       <p>Strategies, standards, and supporting resources to make the Web accessible to people with disabilities.</p>
     </div>
@@ -374,12 +373,12 @@
         <li><a href="https://www.youtube.com/channel/UCU6ljj3m1fglIPjSjs2DpRA/playlistsv"><svg focusable="false" aria-hidden="true" class="icon-youtube " viewBox="0 0 32 32"><path d="M31.327 8.273c-0.386-1.353-1.431-2.398-2.756-2.777l-0.028-0.007c-2.493-0.668-12.528-0.668-12.528-0.668s-10.009-0.013-12.528 0.668c-1.353 0.386-2.398 1.431-2.777 2.756l-0.007 0.028c-0.443 2.281-0.696 4.903-0.696 7.585 0 0.054 0 0.109 0 0.163l-0-0.008c-0 0.037-0 0.082-0 0.126 0 2.682 0.253 5.304 0.737 7.845l-0.041-0.26c0.386 1.353 1.431 2.398 2.756 2.777l0.028 0.007c2.491 0.669 12.528 0.669 12.528 0.669s10.008 0 12.528-0.669c1.353-0.386 2.398-1.431 2.777-2.756l0.007-0.028c0.425-2.233 0.668-4.803 0.668-7.429 0-0.099-0-0.198-0.001-0.297l0 0.015c0.001-0.092 0.001-0.201 0.001-0.31 0-2.626-0.243-5.196-0.708-7.687l0.040 0.258zM12.812 20.801v-9.591l8.352 4.803z"></path></svg> YouTube</a></li>
         <li><a href="https://www.w3.org/WAI/news/subscribe/" class="button">Get News in Email</a></li>
       </ul>
-    </div>
+    </div-->
     <div dir="auto" translate="no" lang="en">
       <p>Copyright © 2025 World Wide Web Consortium (<a href="https://www.w3.org/">W3C</a><sup>®</sup>). See <a href="/WAI/about/using-wai-material/">Permission to Use WAI Material</a>.</p>
     </div>
   </div>
-  <div dir="auto" translate="no" class="q4-start q4-end" lang="en">
+  <!--div dir="auto" translate="no" class="q4-start q4-end" lang="en">
     <ul style="margin-bottom:0">
       <li><a href="/WAI/about/contacting/">Contact WAI</a></li>
       <li><a href="/WAI/sitemap/">Site Map</a></li>
@@ -388,7 +387,7 @@
       <li><a href="/WAI/translations/"> Translations</a></li>
       <li><a href="/WAI/roles/">Resources for Roles</a></li>
     </ul>
-  </div>
+  </div-->
 </footer>
 
 <link rel="stylesheet" href="../a11y-light.css">
@@ -402,7 +401,7 @@
 </script>
 <script src="https://www.w3.org/WAI/assets/scripts/main.js"></script>
 
-<script>
+<!--script>
   var _paq = _paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
   _paq.push(["setDoNotTrack", true]);
@@ -418,7 +417,7 @@
 </script>
 <noscript>
   <p><img src="//www.w3.org/analytics/piwik/piwik.php?idsite=328&amp;rec=1" style="border:0;" alt="" /></p>
-</noscript>
+</noscript-->
 
 
 </body></html>


### PR DESCRIPTION
Close https://github.com/waic/wcag22/issues/843

G211の翻訳です。

raw.githack.com
https://raw.githack.com/waic/wcag22/momdo-G211/techniques/general/G211.html

@caztcha
レビューをお願いします。

主な差分は、解説の第1段落、事例8、手順2と4になります。それらについて新規に訳しています。