### PR TITLE
G134 (廃止)の翻訳

### DIFF
--- a/techniques/general/G134.html
+++ b/techniques/general/G134.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
+<!DOCTYPE html><html lang="ja" xml:lang="ja" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
 <title>[Obsolete] G134: Validating web pages | WAI | W3C</title>
 		
@@ -72,8 +72,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i">This technique relates to 4.1.1: Parsing, which was removed as of WCAG 2.2.
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i">このテクニックは、WCAG 2.2 で削除された 4.1.1: 構文解析に関連している。
 </div>
 </section>
 


### PR DESCRIPTION
Close https://github.com/waic/wcag22/issues/769

廃止されたG134の翻訳です。

raw.githack.com
https://raw.githack.com/waic/wcag22/momdo-G134/techniques/general/G134.html

@caztcha
レビューをお願いします。
