### PR TITLE
fix #1351 未訳部分を日本語に

### DIFF
--- a/understanding/change-on-request.html
+++ b/understanding/change-on-request.html
@@ -257,7 +257,7 @@
                            
                            <p> 
                               
-                              次のテクニックのどれか一つを用いて、<a class="general" href="https://w3c.github.io/wcag/techniques/general/G110">G110: Using an instant client-side redirect</a>    
+                              次のテクニックのどれか一つを用いて、<a class="general" href="https://w3c.github.io/wcag/techniques/general/G110">G110: Using an instant client-side redirect</a>:    
                               
                            </p>
                            


### PR DESCRIPTION
fix #1351 
ひとまず英語を日本語にしました。
この箇所の訳が統一されていない問題がありますが、ひとまず棚上げにして別issueとして https://github.com/waic/wcag22/issues/1400 を立てています。