### PR TITLE
「組合せ」と「組み合わせ」の表記ゆれの解消

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -296,7 +296,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
            <section id="background-on-wcag-2"><div class="header-wrapper"><h3 id="background-on-wcag-2-0">WCAG 2 の背景</h3><a class="self-link" href="#background-on-wcag-2" aria-label="Permalink for this Section"></a></div>
             				
               <p>Web Content Accessibility Guidelines (WCAG) 2.2 は、ウェブコンテンツを障害のある人にとってよりアクセシブルにする方法を定義している。アクセシビリティは、視覚、聴覚、身体、発話、認知、言語、学習、神経の障害を含む、広範な障害に関係している。このガイドラインは、広範囲に及ぶ事項を網羅しているが、障害のすべての種類、程度、組合せからくるニーズを満たすことはできない。また、このガイドラインは、加齢により能力が変化している高齢者にとってもウェブコンテンツをより使いやすくするものであるとともに、しばしば利用者全般のユーザビリティを向上させる。</p>
-              <p>WCAG 2.2 は、ウェブコンテンツのアクセシビリティに対して、様々な国の個人、組織、政府のニーズを満たすような共通の基準を提供することを目的として、 <a href="https://www.w3.org/WAI/standards-guidelines/w3c-process/"><abbr title="World Wide Web Consortium">W3C</abbr> process</a> に従って世界中の個人及び組織の協力のもと作成されている。WCAG 2.2 は、WCAG 1.0 [<cite><a class="bibref" data-link-type="biblio" href="#bib-wai-webcontent" title="Web Content Accessibility Guidelines 1.0">WAI-WEBCONTENT</a></cite>] をベースに作られた WCAG 2.0 [<cite><a class="bibref" data-link-type="biblio" href="#bib-wcag20" title="Web Content Accessibility Guidelines (WCAG) 2.0">WCAG20</a></cite>] 及び WCAG 2.1 [<cite><a class="bibref" data-link-type="biblio" href="#bib-wcag21" title="Web Content Accessibility Guidelines (WCAG) 2.1">WCAG21</a></cite>] をベースに作られており、現在及び将来の様々なウェブ技術に広く適用され、自動テストと人間による評価の組み合わせでテスト可能になるように設計されている。WCAG のイントロダクションとしては、<a href="https://www.w3.org/WAI/standards-guidelines/wcag/">Web Content Accessibility Guidelines (WCAG) Overview</a> を参照。</p>
+              <p>WCAG 2.2 は、ウェブコンテンツのアクセシビリティに対して、様々な国の個人、組織、政府のニーズを満たすような共通の基準を提供することを目的として、 <a href="https://www.w3.org/WAI/standards-guidelines/w3c-process/"><abbr title="World Wide Web Consortium">W3C</abbr> process</a> に従って世界中の個人及び組織の協力のもと作成されている。WCAG 2.2 は、WCAG 1.0 [<cite><a class="bibref" data-link-type="biblio" href="#bib-wai-webcontent" title="Web Content Accessibility Guidelines 1.0">WAI-WEBCONTENT</a></cite>] をベースに作られた WCAG 2.0 [<cite><a class="bibref" data-link-type="biblio" href="#bib-wcag20" title="Web Content Accessibility Guidelines (WCAG) 2.0">WCAG20</a></cite>] 及び WCAG 2.1 [<cite><a class="bibref" data-link-type="biblio" href="#bib-wcag21" title="Web Content Accessibility Guidelines (WCAG) 2.1">WCAG21</a></cite>] をベースに作られており、現在及び将来の様々なウェブ技術に広く適用され、自動テストと人間による評価の組合せでテスト可能になるように設計されている。WCAG のイントロダクションとしては、<a href="https://www.w3.org/WAI/standards-guidelines/wcag/">Web Content Accessibility Guidelines (WCAG) Overview</a> を参照。</p>
             
               <p>認知、言語、及び学習障害に対処するための追加の達成基準を定義するにあたり、勧告策定期間の短さに加えて、勧告案のテスト可能性や実装可能性、国際的な観点からの検討について合意形成に至る際の課題など、重大な課題に向き合うこととなった。こうした領域については、WCAG の将来の版で検討が継続されることになる。コンテンツ制作者においては、<a href="https://www.w3.org/WAI/standards-guidelines/wcag/#supplement">学習障害、認知障害、ロービジョンなど障害のある人のインクルージョンを向上するための補足的なガイダンス</a>を参照することを推奨する。</p>
               
@@ -985,7 +985,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
      <li>単語の間隔をフォントサイズの少なくとも 0.16 倍に設定する</li>
    </ul>
  
- <p>例外: テキスト表記においてこれらのテキストスタイルプロパティの一つ以上を使用しない<a href="#dfn-human-language-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-human-language-s-1" title="人間とコミュニケーションをとるために話される、書かれる、又は (視覚的もしくは触覚的な手段で) 手話にされる言語。">自然言語</a>及び文字体系では、その言語と文字体系の組み合わせに存在するプロパティだけを用いて、この達成基準に適合することができる。</p>
+ <p>例外: テキスト表記においてこれらのテキストスタイルプロパティの一つ以上を使用しない<a href="#dfn-human-language-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-human-language-s-1" title="人間とコミュニケーションをとるために話される、書かれる、又は (視覚的もしくは触覚的な手段で) 手話にされる言語。">自然言語</a>及び文字体系では、その言語と文字体系の組合せに存在するプロパティだけを用いて、この達成基準に適合することができる。</p>
 
  <div class="note" role="note" id="issue-container-generatedID-10"><div role="heading" class="note-title marker" id="h-note-10" aria-level="5"><span>注記 1</span></div><p class="">コンテンツが、これらのテキストの間隔の値を用いる必要はない。要求事項は、コンテンツ制作者が指定したテキストの間隔を利用者が上書きした場合に、コンテンツ又は機能が失われないことである。</p></div>
 
@@ -2679,7 +2679,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
    <div class="note" role="note" id="issue-container-generatedID-95"><div role="heading" class="note-title marker" id="h-note-95" aria-level="3"><span>注記 5</span></div><p class="">文字の周囲に縁取りがある場合、その縁取りがコントラストを強めることもあり、文字とその背景色におけるコントラストの計算に用いられる。文字の周囲の細い縁取りは文字として扱われる。文字の周囲の太い縁取りが、光彩のようになって、文字の内側の細部を塗りつぶしていれば、背景色として考慮されることになる。
    </p></div>
    
-   <div class="note" role="note" id="issue-container-generatedID-96"><div role="heading" class="note-title marker" id="h-note-96" aria-level="3"><span>注記 6</span></div><p class="">WCAG に適合しているか判断する場合は、典型的な提示において隣接するであろうとコンテンツ制作者が想定するコンテンツで指定された色の組み合わせについて評価しなければならない。コンテンツ制作者は、ユーザエージェントによる色の変更などのように通常とは異なる提示を考慮する必要はない。ただし、それがコンテンツ制作者のコードによって起こる場合は除く。
+   <div class="note" role="note" id="issue-container-generatedID-96"><div role="heading" class="note-title marker" id="h-note-96" aria-level="3"><span>注記 6</span></div><p class="">WCAG に適合しているか判断する場合は、典型的な提示において隣接するであろうとコンテンツ制作者が想定するコンテンツで指定された色の組合せについて評価しなければならない。コンテンツ制作者は、ユーザエージェントによる色の変更などのように通常とは異なる提示を考慮する必要はない。ただし、それがコンテンツ制作者のコードによって起こる場合は除く。
    </p></div>
    
 </dd>
@@ -2837,7 +2837,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
    <p>人間とコミュニケーションをとるために話される、書かれる、又は (視覚的もしくは触覚的な手段で) 手話にされる言語。
    </p>
    
-   <div class="note" role="note" id="issue-container-generatedID-105"><div role="heading" class="note-title marker" id="h-note-105" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-sign-language" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-sign-language-1" title="意味を伝えるために、手と腕の動き、顔の表情又は身体の姿勢の組み合わせを用いる言語。">手話</a>も参照。
+   <div class="note" role="note" id="issue-container-generatedID-105"><div role="heading" class="note-title marker" id="h-note-105" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-sign-language" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-sign-language-1" title="意味を伝えるために、手と腕の動き、顔の表情又は身体の姿勢の組合せを用いる言語。">手話</a>も参照。
    </p></div>
    
 </dd>
@@ -3421,7 +3421,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
                 <dt><dfn id="dfn-sign-language" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">手話 (sign language)</dfn></dt>
 <dd>
    
-   <p>意味を伝えるために、手と腕の動き、顔の表情又は身体の姿勢の組み合わせを用いる言語。
+   <p>意味を伝えるために、手と腕の動き、顔の表情又は身体の姿勢の組合せを用いる言語。
    </p>
    
 </dd>
@@ -3430,7 +3430,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
                 <dt><dfn id="dfn-sign-language-interpretation" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">手話通訳 (sign language interpretation)</dfn></dt>
 <dd>
    
-   <p>ある言語、通常は話されている言語を、<a href="#dfn-sign-language" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-sign-language-2" title="意味を伝えるために、手と腕の動き、顔の表情又は身体の姿勢の組み合わせを用いる言語。">手話</a>に訳すこと。</p>
+   <p>ある言語、通常は話されている言語を、<a href="#dfn-sign-language" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-sign-language-2" title="意味を伝えるために、手と腕の動き、顔の表情又は身体の姿勢の組合せを用いる言語。">手話</a>に訳すこと。</p>
    
    <div class="note" role="note" id="issue-container-generatedID-145"><div role="heading" class="note-title marker" id="h-note-145" aria-level="3"><span>注記</span></div><p class="">純粋な手話は、同じ国又は地域の話されている言語とは関係がない独立したものである。
    </p></div>


### PR DESCRIPTION
closes #1863 

WG4翻訳用語集「JIS 原案作成のための手引」に則り、「組合せ」で統一しました。
ただし、活用がある場合は「組み合わせ(る)」のママとしています。