### PR TITLE
「トリガー」「トリガ」の表記ゆれの解消

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -1019,7 +1019,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 
     	<div class="note" role="note" id="issue-container-generatedID-12"><div role="heading" class="note-title marker" id="h-note-12" aria-level="5"><span>注記 1</span></div><p class="">ユーザエージェントによって制御されている追加コンテンツの例としては、<abbr title="HyperText Markup Language">HTML</abbr> の <a href="https://html.spec.whatwg.org/multipage/dom.html#the-title-attribute"><code>title</code> 属性</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-html" title="HTML Standard">HTML</a></cite>] を用いて作られているブラウザのツールチップが挙げられる。</p></div>
      <div class="note" role="note" id="issue-container-generatedID-13"><div role="heading" class="note-title marker" id="h-note-13" aria-level="5"><span>注記 2</span></div><p class="">ホバー時やフォーカス時に表示されるカスタムツールチップ、サブメニュー、他の非モーダルポップアップは、この達成基準の適用対象となる「追加コンテンツ」の例である。</p></div>
-     <div class="note" role="note" id="issue-container-generatedID-14"><div role="heading" class="note-title marker" id="h-note-14" aria-level="5"><span>注記 3</span></div><p class="">この達成基準は、トリガーとなるコンポーネント自体に追加で表示されるコンテンツに対して適用される。キーボードフォーカスによって可視化される非表示のコンポーネント (例えば、ページの別の部分にスキップするためのリンク) は追加コンテンツを提示しないため、この達成基準の適用対象外である。</p></div>
+     <div class="note" role="note" id="issue-container-generatedID-14"><div role="heading" class="note-title marker" id="h-note-14" aria-level="5"><span>注記 3</span></div><p class="">この達成基準は、トリガとなるコンポーネント自体に追加で表示されるコンテンツに対して適用される。キーボードフォーカスによって可視化される非表示のコンポーネント (例えば、ページの別の部分にスキップするためのリンク) は追加コンテンツを提示しないため、この達成基準の適用対象外である。</p></div>
   </section>
 
 
@@ -1085,7 +1085,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
    					
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG22/Understanding/character-key-shortcuts.html">Understanding Character Key Shortcuts</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG22/quickref/#character-key-shortcuts">How to Meet Character Key Shortcuts</a></div><p class="conformance-level">(レベル A)</p>
    					
-  <p>文字 (大文字と小文字を含む)、句読点、数字、又は記号のみを使用した<a href="#dfn-keyboard-shortcuts" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-keyboard-shortcuts-1" title="一つ以上のキーを押すことによる、動作のトリガーの代替手段">キーボードショートカット</a>がコンテンツに実装されている場合、少なくとも次のいずれかを満たしている:</p>
+  <p>文字 (大文字と小文字を含む)、句読点、数字、又は記号のみを使用した<a href="#dfn-keyboard-shortcuts" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-keyboard-shortcuts-1" title="一つ以上のキーを押すことによる、動作のトリガの代替手段">キーボードショートカット</a>がコンテンツに実装されている場合、少なくとも次のいずれかを満たしている:</p>
 
   <dl>
    
@@ -2939,7 +2939,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
                 <dt><dfn id="dfn-keyboard-shortcuts" data-lt="keyboard shortcuts|keyboard shortcut" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">キーボードショートカット (keyboard shortcut)</dfn></dt>
 <dd>
    					
-   <p>一つ以上のキーを押すことによる、動作のトリガーの代替手段</p>
+   <p>一つ以上のキーを押すことによる、動作のトリガの代替手段</p>
    				
 </dd>
 


### PR DESCRIPTION
close #1866 

WG4翻訳用語集に則り、「トリガ」で統一しました。