### PR TITLE
「対して」の除去 - 「1.2.5 音声解説 (収録済み)」の見直し

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -543,8 +543,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG22/Understanding/audio-description-prerecorded.html">Understanding Audio Description (Prerecorded)</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG22/quickref/#audio-description-prerecorded">How to Meet Audio Description (Prerecorded)</a></div><p class="conformance-level">(レベル AA)</p>
    
-   <p><a href="#dfn-synchronized-media" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-synchronized-media-4" title="情報を提示するために、他のフォーマットと同期した音声もしくは映像、及び／又は時間ベースのインタラクティブな構成要素と同期した音声もしくは映像。ただし、そのメディアがメディアによるテキストの代替であって、そのように明確にラベル付けされているものは除く。">同期したメディア</a>に含まれているすべての<a href="#dfn-prerecorded" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-prerecorded-4" title="ライブではない情報。">収録済の</a><a href="#dfn-video" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-video-2" title="写真又は画像を動かす、又はシーケンス化する技術。">映像</a>コンテンツに対して、<a href="#dfn-audio-descriptions" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-audio-descriptions-2" title="主音声のトラックだけでは理解できない重要で視覚的な詳細を説明するために、音声トラックに追加されたナレーション。">音声解説</a>が提供されている。
-   </p>
+   <p><a href="#dfn-synchronized-media" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-synchronized-media-4" title="情報を提示するために、他のフォーマットと同期した音声もしくは映像、及び／又は時間ベースのインタラクティブな構成要素と同期した音声もしくは映像。ただし、そのメディアがメディアによるテキストの代替であって、そのように明確にラベル付けされているものは除く。">同期したメディア</a>に含まれている全ての<a href="#dfn-prerecorded" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-prerecorded-4" title="ライブではない情報。">収録済みの</a><a href="#dfn-video" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-video-2" title="写真又は画像を動かす、又はシーケンス化する技術。">映像</a>コンテンツには、<a href="#dfn-audio-descriptions" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-audio-descriptions-2" title="主音声のトラックだけでは理解できない重要で視覚的な詳細を説明するために、音声トラックに追加されたナレーション。">音声解説</a>が提供されている。</p>
    
 </section>
 


### PR DESCRIPTION
close #1548

「対して」の除去