### PR TITLE
解説書: title 要素内の余計なスペースの削除

### DIFF
--- a/understanding/character-key-shortcuts.html
+++ b/understanding/character-key-shortcuts.html
@@ -3,7 +3,7 @@
    <head>
       <meta charset="UTF-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <title>解説書 達成基準  2.1.4: 文字キーのショートカット | WAI | W3C</title>
+      <title>解説書 達成基準 2.1.4: 文字キーのショートカット | WAI | W3C</title>
       <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css" />
       <link rel="stylesheet" href="base.css" />
    </head>

--- a/understanding/content-on-hover-or-focus.html
+++ b/understanding/content-on-hover-or-focus.html
@@ -3,7 +3,7 @@
    <head>
       <meta charset="UTF-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <title>解説書 達成基準  1.4.13: ホバー又はフォーカスで表示されるコンテンツ | WAI | W3C</title>
+      <title>解説書 達成基準 1.4.13: ホバー又はフォーカスで表示されるコンテンツ | WAI | W3C</title>
       <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css" />
       <link rel="stylesheet" href="base.css" />
    </head>

--- a/understanding/contrast-enhanced.html
+++ b/understanding/contrast-enhanced.html
@@ -3,7 +3,7 @@
    <head>
       <meta charset="UTF-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <title>解説書 達成基準  1.4.6: コントラスト (高度) | WAI | W3C</title>
+      <title>解説書 達成基準 1.4.6: コントラスト (高度) | WAI | W3C</title>
       <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css" />
       <link rel="stylesheet" href="base.css" />
    </head>

--- a/understanding/contrast-minimum.html
+++ b/understanding/contrast-minimum.html
@@ -3,7 +3,7 @@
    <head>
       <meta charset="UTF-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <title>解説書 達成基準  1.4.3: コントラスト (最低限) | WAI | W3C</title>
+      <title>解説書 達成基準 1.4.3: コントラスト (最低限) | WAI | W3C</title>
       <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css" />
       <link rel="stylesheet" href="base.css" />
    </head>

--- a/understanding/images-of-text-no-exception.html
+++ b/understanding/images-of-text-no-exception.html
@@ -3,7 +3,7 @@
    <head>
       <meta charset="UTF-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <title>解説書 達成基準  1.4.9: 文字画像 (例外なし) | WAI | W3C</title>
+      <title>解説書 達成基準 1.4.9: 文字画像 (例外なし) | WAI | W3C</title>
       <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css" />
       <link rel="stylesheet" href="base.css" />
    </head>

--- a/understanding/images-of-text.html
+++ b/understanding/images-of-text.html
@@ -3,7 +3,7 @@
    <head>
       <meta charset="UTF-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <title>解説書 達成基準  1.4.5: 文字画像 | WAI | W3C</title>
+      <title>解説書 達成基準 1.4.5: 文字画像 | WAI | W3C</title>
       <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css" />
       <link rel="stylesheet" href="base.css" />
    </head>

--- a/understanding/intro.html
+++ b/understanding/intro.html
@@ -3,7 +3,7 @@
    <head>
       <meta charset="UTF-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <title>解説書 WCAG 解説書のイントロダクション  | WAI | W3C</title>
+      <title>解説書 WCAG 解説書のイントロダクション | WAI | W3C</title>
       <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css" />
       <link rel="stylesheet" href="base.css" />
    </head>

--- a/understanding/keyboard.html
+++ b/understanding/keyboard.html
@@ -3,7 +3,7 @@
    <head>
       <meta charset="UTF-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <title>解説書 達成基準  2.1.1: キーボード | WAI | W3C</title>
+      <title>解説書 達成基準 2.1.1: キーボード | WAI | W3C</title>
       <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css" />
       <link rel="stylesheet" href="base.css" />
    </head>

--- a/understanding/low-or-no-background-audio.html
+++ b/understanding/low-or-no-background-audio.html
@@ -3,7 +3,7 @@
    <head>
       <meta charset="UTF-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <title>解説書 達成基準  1.4.7: 小さな背景音、又は背景音なし | WAI | W3C</title>
+      <title>解説書 達成基準 1.4.7: 小さな背景音、又は背景音なし | WAI | W3C</title>
       <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css" />
       <link rel="stylesheet" href="base.css" />
    </head>

--- a/understanding/non-text-contrast.html
+++ b/understanding/non-text-contrast.html
@@ -3,7 +3,7 @@
    <head>
       <meta charset="UTF-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <title>解説書 達成基準  1.4.11: 非テキストのコントラスト | WAI | W3C</title>
+      <title>解説書 達成基準 1.4.11: 非テキストのコントラスト | WAI | W3C</title>
       <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css" />
       <link rel="stylesheet" href="base.css" />
    </head>

--- a/understanding/parsing.html
+++ b/understanding/parsing.html
@@ -3,7 +3,7 @@
    <head>
       <meta charset="UTF-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <title>解説書 達成基準  4.1.1: 構文解析 (廃止・削除) | WAI | W3C</title>
+      <title>解説書 達成基準 4.1.1: 構文解析 (廃止・削除) | WAI | W3C</title>
       <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css" />
       <link rel="stylesheet" href="base.css" />
    </head>

--- a/understanding/reflow.html
+++ b/understanding/reflow.html
@@ -3,7 +3,7 @@
    <head>
       <meta charset="UTF-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <title>解説書 達成基準  1.4.10: リフロー | WAI | W3C</title>
+      <title>解説書 達成基準 1.4.10: リフロー | WAI | W3C</title>
       <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css" />
       <link rel="stylesheet" href="base.css" />
    </head>

--- a/understanding/resize-text.html
+++ b/understanding/resize-text.html
@@ -3,7 +3,7 @@
    <head>
       <meta charset="UTF-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <title>解説書 達成基準  1.4.4: テキストのサイズ変更 | WAI | W3C</title>
+      <title>解説書 達成基準 1.4.4: テキストのサイズ変更 | WAI | W3C</title>
       <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css" />
       <link rel="stylesheet" href="base.css" />
    </head>

--- a/understanding/text-spacing.html
+++ b/understanding/text-spacing.html
@@ -3,7 +3,7 @@
    <head>
       <meta charset="UTF-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <title>解説書 達成基準  1.4.12: テキストの間隔 | WAI | W3C</title>
+      <title>解説書 達成基準 1.4.12: テキストの間隔 | WAI | W3C</title>
       <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css" />
       <link rel="stylesheet" href="base.css" />
    </head>

--- a/understanding/visual-presentation.html
+++ b/understanding/visual-presentation.html
@@ -3,7 +3,7 @@
    <head>
       <meta charset="UTF-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <title>解説書 達成基準  1.4.8: 視覚的提示 | WAI | W3C</title>
+      <title>解説書 達成基準 1.4.8: 視覚的提示 | WAI | W3C</title>
       <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css" />
       <link rel="stylesheet" href="base.css" />
    </head>


### PR DESCRIPTION
close #1924 

解説書の `<title>` 要素内にある、余計な重複スペースを削除しました。

以下の15箇所が、該当箇所です。

`<title>解説書 達成基準  1.4.3: コントラスト (最低限) | WAI | W3C</title>`
`<title>解説書 達成基準  1.4.4: テキストのサイズ変更 | WAI | W3C</title>`
`<title>解説書 達成基準  1.4.5: 文字画像 | WAI | W3C</title>`
`<title>解説書 達成基準  1.4.6: コントラスト (高度) | WAI | W3C</title>`
`<title>解説書 達成基準  1.4.7: 小さな背景音、又は背景音なし | WAI | W3C</title>`
`<title>解説書 達成基準  1.4.8: 視覚的提示 | WAI | W3C</title>`
`<title>解説書 達成基準  1.4.9: 文字画像 (例外なし) | WAI | W3C</title>`
`<title>解説書 達成基準  1.4.10: リフロー | WAI | W3C</title>`
`<title>解説書 達成基準  1.4.11: 非テキストのコントラスト | WAI | W3C</title>`
`<title>解説書 達成基準  1.4.12: テキストの間隔 | WAI | W3C</title>`
`<title>解説書 達成基準  1.4.13: ホバー又はフォーカスで表示されるコンテンツ | WAI | W3C</title>`
`<title>解説書 達成基準  2.1.1: キーボード | WAI | W3C</title>`
`<title>解説書 達成基準  2.1.4: 文字キーのショートカット | WAI | W3C</title>`
`<title>解説書 達成基準  4.1.1: 構文解析 (廃止・削除) | WAI | W3C</title>`
`<title>解説書 WCAG 解説書のイントロダクション  | WAI | W3C</title>`