### PR TITLE
「1.3.6 目的の特定」の見直し

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -675,7 +675,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
    					
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG22/Understanding/identify-purpose.html">Understanding Identify Purpose</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG22/quickref/#identify-purpose">How to Meet Identify Purpose</a></div><p class="conformance-level">(レベル AAA)</p>
    					
-  <p>マークアップ言語で実装されたコンテンツでは、<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-interface-components-1" title="コンテンツの一部分で、特定の機能を実現するための単一のコントロールとして利用者が知覚するもの。">ユーザインタフェース コンポーネント</a>、アイコン、<a href="#dfn-regions" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-regions-1" title="コンテンツの知覚可能、プログラムによる解釈が可能なセクション">領域</a>の目的は<a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-programmatically-determinable-4" title="支援技術を含む様々なユーザエージェントが抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。">プログラムによる解釈が可能</a>である。</p>
+  <p>マークアップ言語で実装されたコンテンツでは、<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-interface-components-1" title="コンテンツの一部分で、特定の機能を実現するための単一のコントロールとして利用者が知覚するもの。">ユーザインタフェース コンポーネント</a>、アイコン及び<a href="#dfn-regions" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-regions-1" title="コンテンツの知覚可能、プログラムによる解釈が可能なセクション">領域</a>の目的は<a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-programmatically-determinable-4" title="支援技術を含む様々なユーザエージェントが抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。">プログラムによる解釈が可能</a>である。</p>
 </section>
 
 


### PR DESCRIPTION
Close #1559

「及び」が抜けているのを修正します。