### PR TITLE
「7. ユーザインタフェース コンポーネントの入力目的」の見直し

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -3721,7 +3721,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
     	    	
       <section id="input-purposes"><div class="header-wrapper"><h2 id="x7-input-purposes-for-user-interface-components"><bdi class="secno">7. </bdi>ユーザインタフェース コンポーネントの入力目的</h2><a class="self-link" href="#input-purposes" aria-label="Permalink for Section 7."></a></div>
 	
-	<p>この節には一般的な<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-interface-components-17" title="コンテンツの一部分で、特定の機能を実現するための単一のコントロールとして利用者が知覚するもの。">ユーザインタフェース コンポーネント</a>の入力目的の一覧が含まれる。以下の用語は、使わなければならないキーワードというわけではない。そのかわり、これらのキーワードは目的を表現するものとなり、ウェブページに適用されている分類法の観点でとらえなければならないことになる。コンテンツ制作者は、できれば、セマンティック上の目的を示すよう選ばれた分類法でコントロールをマークアップする。これはユーザエージェントと支援技術に、より多くの人々がコンテンツを理解し使用できるようにする個別化された提示を適用する可能性を提供する。</p>
+	<p>この節には一般的な<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-interface-components-17" title="コンテンツの一部分で、特定の機能を実現するための単一のコントロールとして利用者が知覚するもの。">ユーザインタフェース コンポーネント</a>の入力目的の一覧が含まれる。以下の用語は、使わなければならないキーワードというわけではない。そのかわり、これらのキーワードは目的を表現するものとなり、ウェブページに適用されている分類法の観点でとらえなければならないことになる。コンテンツ制作者は、できれば、セマンティック上の目的を示すよう選ばれた分類法でコントロールをマークアップする。これはユーザエージェントと支援技術に、より多くの人々がコンテンツを理解し使用できるようにするパーソナライズされた提示を適用する可能性を提供する。</p>
   
   <div class="note" role="note" id="issue-container-generatedID-160"><div role="heading" class="note-title marker" id="h-note-160" aria-level="3"><span>注記</span></div><p class="">入力タイプの目的の一覧は、<a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill"><abbr title="HyperText Markup Language">HTML</abbr> specification の Autofill のセクション</a>で定義されているコントロールの目的に基づいている。しかし、異なるウェブコンテンツ技術は、HTML 仕様で定義されているものと同じ概念の一部又は全部を持ってもよく、以下で示される意味に対応付けられているその概念のみが要求されることを理解することが重要である。</p></div>
   <div class="note"><div role="heading" class="note-title marker" aria-level="5"><span>訳注</span></div><p>この節での「セマンティック上の」という記載の趣旨は、ウェブを構成するシステムが意味的に正確に解釈できるような、というものである。</p></div>
@@ -3731,12 +3731,12 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 	<ul>
 		<li><code class="language-html">name</code> - フルネーム</li>
 		<li><code class="language-html">honorific-prefix</code> - 敬称又は称号 (例えば、"Mr."、"Ms."、"Dr."、"M<sup>lle</sup>")</li>
-		<li><code class="language-html">given-name</code> - Given name (一部の西洋文化において、<i>first name</i> として知られる)</li>
-		<li><code class="language-html">additional-name</code> - Additional names (一部の西洋文化において、<i>middle names</i> として知られる、姓の前にあるファーストネームではない名前)</li>
-		<li><code class="language-html">family-name</code> - Family name (一部の西洋文化において、<i>last name</i> 又は <i>surname</i> として知られる)</li>
+		<li><code class="language-html">given-name</code> - 名 (一部の西洋文化において、<i>first name</i> として知られる)</li>
+		<li><code class="language-html">additional-name</code> - 追加の名前 (一部の西洋文化において、<i>middle names</i> として知られる、姓の前にあるファーストネームではない名前)</li>
+		<li><code class="language-html">family-name</code> - 名字 (一部の西洋文化において、<i>last name</i> 又は <i>surname</i> として知られる)</li>
 		<li><code class="language-html">honorific-suffix</code> - 接尾語 (例えば、"Jr."、"B.Sc."、"MBASW"、"II")</li>
 		<li><code class="language-html">nickname</code> - ニックネーム、スクリーンネーム、ハンドル: フルネームの代わりに使用する一般的に短い名前</li>
-		<li><code class="language-html">organization-title</code> - 職種 (例えば"Software Engineer"、"Senior Vice President"、"Deputy Managing Director")</li>
+		<li><code class="language-html">organization-title</code> - 役職 (例えば、「ソフトウェアエンジニア」「上級副社長」「取締役補佐」)</li>
 		<li><code class="language-html">username</code> - ユーザ名</li>
 		<li><code class="language-html">new-password</code> - 新しいパスワード (例えば、アカウントの作成又はパスワードの変更の場合)</li>
 		<li><code class="language-html">current-password</code> - <code class="language-html">username</code> フィールドによって識別されるアカウントに対する現在のパスワード (例えば、ログイン時)</li>
@@ -3754,9 +3754,9 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 		<li><code class="language-html">postal-code</code> - 郵便番号、ZIP コード、CEDEX コード (CEDEX の場合、"CEDEX" と付け加え、必要に応じて、<i lang="fr">arrondissement</i> を <code class="language-html">address-level2</code> フィールドに追加する)
         <div class="note"><div role="heading" class="note-title marker" aria-level="3"><span>訳注</span></div><p>CEDEX はフランスで私書箱に使われる住所表記、<i lang="fr">arrondissement</i> はフランスの行政区画を指す。</p></div></li>
 		<li><code class="language-html">cc-name</code> - 決済手段に与えられるようなフルネーム</li>
-		<li><code class="language-html">cc-given-name</code> - 決済手段に与えられるような Given name (一部の西洋文化において、<i>first name</i> として知られる)</li>
-		<li><code class="language-html">cc-additional-name</code> - 決済手段に与えられるような Additional names (一部の西洋文化において、 <i>middle names</i> として知られる)</li>
-		<li><code class="language-html">cc-family-name</code> - 決済手段に与えられるような Family name (一部の西洋文化において、<i>last name</i> 又は <i>surname</i> として知られる)</li>
+		<li><code class="language-html">cc-given-name</code> - 決済手段に与えられるような名 (一部の西洋文化において、<i>first name</i> として知られる)</li>
+		<li><code class="language-html">cc-additional-name</code> - 決済手段に与えられるような追加の名前 (一部の西洋文化において、 <i>middle names</i> として知られる)</li>
+		<li><code class="language-html">cc-family-name</code> - 決済手段に与えられるような名字 (一部の西洋文化において、<i>last name</i> 又は <i>surname</i> として知られる)</li>
 		<li><code class="language-html">cc-number</code> - 決済手段 (例えばクレジットカード番号) を識別するコード</li>
 		<li><code class="language-html">cc-exp</code> - 決済手段の有効期限</li>
 		<li><code class="language-html">cc-exp-month</code> - 決済手段の有効期限の月コンポーネント</li>
@@ -3764,7 +3764,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 		<li><code class="language-html">cc-csc</code> - 決済手段のセキュリティーコード (カードのセキュリティーコード (CSC)、カード検証コード (CVC)、カード検証値 (CVV)、署名欄コード (SPC)、クレジットカード ID (CCID) などとして知られている)</li>
 		<li><code class="language-html">cc-type</code> - 決済手段の種類</li>
 		<li><code class="language-html">transaction-currency</code> - 利用者が取引での使用を望む通貨</li>
-		<li><code class="language-html">transaction-amount</code> - (例えば、ビッド又は販売価格を入力する時に) 利用者が取引したい金額</li>
+		<li><code class="language-html">transaction-amount</code> - (例えば、入札価格又は販売価格を入力する時に) 利用者が取引したい金額</li>
 		<li><code class="language-html">language</code> - 優先言語</li>
 		<li><code class="language-html">bday</code> - 誕生日</li>
 		<li><code class="language-html">bday-day</code> - 誕生日の日のコンポーネント</li>


### PR DESCRIPTION
Close #1659

personalized presentationsを「パーソナライズされた提示」に

Given name、Additional names、Family nameをそれぞれ「名」、「追加の名前」、「名字」に

> organization-title - Job title (e.g., "Software Engineer", "Senior Vice President", "Deputy Managing Director")

「職種」を「役職」に、
"Software Engineer"、"Senior Vice President"、"Deputy Managing Director"をそれぞれ
「ソフトウェアエンジニア」「上級副社長」「取締役補佐」に

> transaction-amount - The amount that the user would like for the transaction (e.g., when entering a bid or sale price)

「ビッド」を「入札価格」に
