### PR TITLE
「補足コンテンツ」の title 属性の修正漏れ

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -1707,7 +1707,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG22/Understanding/reading-level.html">Understanding Reading Level</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG22/quickref/#reading-level">How to Meet Reading Level</a></div><p class="conformance-level">(レベル AAA)</p>
    
-  <p>固有名詞及び題名を取り除いた後に、テキストが<a href="#dfn-lower-secondary-education-level" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-lower-secondary-education-level-1" title="6 年間の学校教育修了の後に始まり、初等教育の開始から 9 年後に終わる、2 年、又は 3 年の教育期間。">前期中等教育レベル</a>を超えた読解力を必要とする場合は、<a href="#dfn-supplementary-content" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-supplementary-content-1" title="元のコンテンツを説明、又はより明確にするために付加されたコンテンツ。">補足コンテンツ</a>又は前期中等教育レベルを超えた読解力を必要としない版が利用可能である。
+  <p>固有名詞及び題名を取り除いた後に、テキストが<a href="#dfn-lower-secondary-education-level" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-lower-secondary-education-level-1" title="6 年間の学校教育修了の後に始まり、初等教育の開始から 9 年後に終わる、2 年、又は 3 年の教育期間。">前期中等教育レベル</a>を超えた読解力を必要とする場合は、<a href="#dfn-supplementary-content" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-supplementary-content-1" title="主要なコンテンツを説明又は明確にする追加コンテンツ。">補足コンテンツ</a>又は前期中等教育レベルを超えた読解力を必要としない版が利用可能である。
    </p>
    
 </section>


### PR DESCRIPTION
PR #2013 で対応した「補足コンテンツ」の title 属性値の修正が、一部漏れていたため、対応しました。