### PR TITLE
「2.5.2 ポインタのキャンセル」見出しの「SC」を「達成基準」に修正

### DIFF
--- a/understanding/pointer-cancellation.html
+++ b/understanding/pointer-cancellation.html
@@ -72,7 +72,7 @@
          <main id="main" class="standalone-resource__main">
 
             <h1><span class="standalone-resource__type-of-guidance">解説書 
-                  				SC 2.5.2:</span>ポインタのキャンセル (レベル A)
+                  				達成基準 2.5.2:</span>ポインタのキャンセル (レベル A)
             </h1>
             <aside class="box">
                <header class="box-h  box-h-icon">達成基準</header>


### PR DESCRIPTION
「2.5.2 ポインタのキャンセル」　`h1` 内で原文の表記「SC」が使用されているため、他解説書同様の表記に修正しました。

https://waic.jp/translations/WCAG22/Understanding/pointer-cancellation