### PR TITLE
音声だけ (audio-only) の追加修正

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -850,7 +850,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG22/Understanding/low-or-no-background-audio.html">Understanding Low or No Background Audio</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG22/quickref/#low-or-no-background-audio">How to Meet Low or No Background Audio</a></div><p class="conformance-level">(レベル AAA)</p>
    
-   <p><a href="#dfn-prerecorded" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-prerecorded-8" title="ライブではない情報。">収録済み</a>の<a href="#dfn-audio-only" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-audio-only-3" title="音声のみを含んだ、時間ベースの提示 (映像やインタラクションを含まない)。">音声しか</a>含まないコンテンツで、(1) 前景に主として発話を含み、(2) 音声 <a href="#dfn-captcha" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-captcha-2" title="コンピュータと人間とを区別するための完全に自動化された公開チューリングテスト (Completely Automated Public Turing test to tell Computers and Humans Apart) の頭文字語。">CAPTCHA</a> 又は音声ロゴではなく、かつ、(3) 歌、ラップなどの、主として音楽表現を意図した発声ではないものについては、次に挙げる事項のうち、少なくとも一つを満たしている:
+   <p><a href="#dfn-prerecorded" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-prerecorded-8" title="ライブではない情報。">収録済み</a>の<a href="#dfn-audio-only" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-audio-only-3" title="音声だけを含んだ (映像もインタラクションも含まない)、時間ベースの提示。">音声だけ</a>のコンテンツで、(1) 前景に主として発話を含み、(2) 音声 <a href="#dfn-captcha" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-captcha-2" title="コンピュータと人間とを区別するための完全に自動化された公開チューリングテスト (Completely Automated Public Turing test to tell Computers and Humans Apart) の頭文字語。">CAPTCHA</a> 又は音声ロゴではなく、かつ、(3) 歌、ラップなどの、主として音楽表現を意図した発声ではないものについては、次に挙げる事項のうち、少なくとも一つを満たしている:
    </p>
    
    <dl>


### PR DESCRIPTION
関連 
- pull request #2026
- issue #1435 

audio-only を「音声だけ」と訳すにあたり、達成基準 1.4.7 において、他のプルリクエストで修正対応がなされていない箇所があるので、追加修正します。

> 収録済みの**音声しか含まない**コンテンツで、...

を

> 収録済みの**音声だけの**コンテンツで、...

に修正しています。

