### PR TITLE
「5.3.2 適合表明の任意要素」の修正

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -2120,13 +2120,13 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
                     
                     <p>上記の適合表明の必須要素に加えて、利用者のために追加で情報を提供することを検討する。追加する情報として推奨するものを以下に挙げる:</p>
                     <ul>
-                        <li>表明した適合レベルよりも上の適合レベルで満たしている達成基準のリスト。この情報は、利用者が使用できる形式で提供すべきで、機械的に読み取れるメタデータが好ましい。</li>
+                        <li>表明した適合レベルよりも上の適合レベルで満たしている達成基準のリスト。この情報は、利用者が使用できる形式で提供すべきで、機械可読なメタデータが好ましい。</li>
                         <li>「<em>使用しているが適合には<a href="#dfn-relied-upon" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-relied-upon-5" title="その技術が無効になっている場合、又はサポートされていない場合に、コンテンツが適合できないこと。">依存</a>していない</em>」技術のリスト。</li>
                         <li>コンテンツを試験するのに用いた、支援技術を含むユーザエージェントのリスト。</li>
-                        <li>機械可読メタデータで提供される、コンテンツのアクセシビリティ特性のリスト。</li>
+                        <li>機械可読なメタデータで提供される、コンテンツのアクセシビリティ特性のリスト。</li>
                         <li>アクセシビリティを向上させるために達成基準を超えて追加で施した措置に関する情報。</li>
-                        <li><a href="#dfn-relied-upon" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-relied-upon-6" title="その技術が無効になっている場合、又はサポートされていない場合に、コンテンツが適合できないこと。">依存</a>している技術を示したリストの機械的に読み取れるメタデータ版。</li>
-                        <li>適合表明の機械的に読み取れるメタデータ版。</li>
+                        <li><a href="#dfn-relied-upon" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-relied-upon-6" title="その技術が無効になっている場合、又はサポートされていない場合に、コンテンツが適合できないこと。">依存</a>している技術を示したリストの機械可読なメタデータ版。</li>
+                        <li>適合表明の機械可読なメタデータ版。</li>
                     </ul>
 
                 	<div class="note" role="note" id="issue-container-generatedID-54"><div role="heading" class="note-title marker" id="h-note-54" aria-level="5"><span>注記 1</span></div><p class="">より多くの情報や適合表明の事例は、<a href="https://www.w3.org/WAI/WCAG22/Understanding/conformance#conformance-claims">Understanding Conformance Claims</a> を参照。</p></div>


### PR DESCRIPTION
close #1654 

machine-readable metadata の訳が揺れていたので、揃えました。