### PR TITLE
村田先生の誤訳指摘に対応

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -898,7 +898,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
    <ul>
      <li>利用者が、前景色と背景色とを選択できる。</li>   
      <li>幅が 80 字を越えない (全角文字の場合は、40 字)。</li>   
-     <li>テキストが、均等割り付けされていない (両端揃えではない)。</li>   
+     <li>テキストが、均等割り付けされていない (左マージンと右マージンの両方に揃えることはしない)。</li>   
      <li>段落中の行送りは、少なくとも 1.5 文字分ある。そして、段落の間隔は、その行送りの少なくとも 1.5 倍以上ある。</li>   
      <li>テキストは、<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-assistive-technologies-3" title="障害のある利用者の要件を満たすために、主流のユーザエージェントが提供する機能を超えた機能を提供するような、ユーザエージェントとして動作する、又は主流のユーザエージェントと共に動作するハードウェア及び／又はソフトウェア。">支援技術</a>なしで 200％までサイズ変更でき、利用者が<a href="#dfn-on-a-full-screen-window" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-on-a-full-screen-window-1" title="最も普及したサイズのデスクトップ又はラップトップのディスプレイで、ビューポートを最大化した状態。">全画面表示のウィンドウで</a> 1 行のテキストを読むときに横スクロールする必要がない。</li>    
   </ul>
@@ -977,9 +977,9 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
    <p>次の<a href="#dfn-text" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-text-7" title="プログラムによる解釈が可能な文字のシーケンスで、自然言語で何かを表現しているもの。">テキスト</a><a href="#dfn-style-properties" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-style-properties-1" title="ユーザエージェントによってコンテンツ要素が (画面、音声スピーカー、点字ディスプレイなどを介して) レンダリングされるとき、その値の提示 (フォント、色、サイズ、位置、パディング、音量、合成音声の韻律など) を定義するプロパティ。">スタイルプロパティ</a>をサポートするマークアップ言語を用いて実装されているコンテンツにおいては、次を全て設定し、かつ他のスタイルプロパティを変更しない場合に、コンテンツ又は機能の損失が生じない:</p>
    
    <ul>
-     <li>行の間隔 (行送り) をフォントサイズの少なくとも 1.5 倍に設定する</li>
+     <li>行の高さ (行送り) をフォントサイズの少なくとも 1.5 倍に設定する</li>
      <li>段落に続く間隔をフォントサイズの少なくとも 2 倍に設定する</li>
-     <li>文字の間隔 (字送り) をフォントサイズの少なくとも 0.12 倍に設定する</li>
+     <li>文字の間隔 (字間) をフォントサイズの少なくとも 0.12 倍に設定する</li>
      <li>単語の間隔をフォントサイズの少なくとも 0.16 倍に設定する</li>
    </ul>
  


### PR DESCRIPTION
村田先生から次のようなご指摘をいただいた:

>この達成基準の箇条書きの項3は、誤訳だと思います。
>文字の間隔 (字送り) をフォントサイズの少なくとも 0.12 倍に設定する
>字送りとは、同一行の隣接する文字同士の基準点から基準点までの距離のことだとJIS Z 8125（印刷用語－デジタル印刷）で定義されています。それが0.12倍だと、字が重なってしまいます。
>正しい訳語は、字間です。これは、 同一行の隣接する2つの文字の外枠の間隔だとJLreqでは定義されています。

WG6-SG1で議論し、

行の間隔 (行送り)  → 行の高さ (行送り) 
文字の間隔 (字送り) → 文字の間隔 (字間) 

とすることにした。

また、以下の修正案もいただいた:

>テキストが、均等割り付けされていない (左マージンと右マージンの両方に揃えることはしない）
>IDTとするなら、aligned to both the left and the right marginsを正確に訳すことが必要。

これらを反映した。