### PR TITLE
activity の翻訳修正

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -1370,7 +1370,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG22/Understanding/multiple-ways.html">Understanding Multiple Ways</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG22/quickref/#multiple-ways">How to Meet Multiple Ways</a></div><p class="conformance-level">(レベル AA)</p>
    
-   <p><a href="#dfn-set-of-web-pages" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-set-of-web-pages-1" title="共通の目的を共有し、同じコンテンツ制作者、グループ、又は組織により制作されたウェブページの集合。">ウェブページ一式</a>の中で、ある<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-6" title="HTTP を使用して単一の URI から取得された埋め込まれていないリソースに加え、レンダリングに使われる、又はユーザエージェントがこのリソースと一緒にレンダリングすることを意図しているあらゆるその他のリソースを合わせたもの。">ウェブページ</a>を見つける複数の経路が利用可能である。ただし、そのウェブページが<a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-1" title="一連の利用者の動作で、それぞれの動作はある活動を完了させるために必須であるもの。">プロセス</a>の結果、又はプロセス中の 1 ステップである場合を除く。
+   <p><a href="#dfn-set-of-web-pages" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-set-of-web-pages-1" title="共通の目的を共有し、同じコンテンツ制作者、グループ、又は組織により制作されたウェブページの集合。">ウェブページ一式</a>の中で、ある<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-6" title="HTTP を使用して単一の URI から取得された埋め込まれていないリソースに加え、レンダリングに使われる、又はユーザエージェントがこのリソースと一緒にレンダリングすることを意図しているあらゆるその他のリソースを合わせたもの。">ウェブページ</a>を見つける複数の経路が利用可能である。ただし、そのウェブページが<a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-1" title="一連の利用者の動作で、それぞれの動作はあるアクティビティを完了させるために必須であるもの。">プロセス</a>の結果、又はプロセス中の 1 ステップである場合を除く。
    </p>
    
 </section>
@@ -1909,7 +1909,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
     <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html">Understanding Redundant Entry</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG22/quickref/#redundant-entry">How to Meet Redundant Entry</a></div><p class="conformance-level">(レベル A)</p>
 	<p class="change">New</p>
     
-    <p>以前に利用者によって入力された、又は利用者に対して提供された情報であって、同一の<a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-2" title="一連の利用者の動作で、それぞれの動作はある活動を完了させるために必須であるもの。">プロセス</a>において再入力する必要がある情報は、次のいずれかである:</p>
+    <p>以前に利用者によって入力された、又は利用者に対して提供された情報であって、同一の<a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-2" title="一連の利用者の動作で、それぞれの動作はあるアクティビティを完了させるために必須であるもの。">プロセス</a>において再入力する必要がある情報は、次のいずれかである:</p>
 
     <ul>
         <li>自動入力される。又は、</li>
@@ -1932,7 +1932,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
     <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum.html">Understanding Accessible Authentication (Minimum)</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG22/quickref/#accessible-authentication-minimum">How to Meet Accessible Authentication (Minimum)</a></div><p class="conformance-level">(レベル AA)</p>
 	<p class="change">New</p>
     
-    <p><a href="#dfn-cognitive-function-test" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-cognitive-function-test-1" title="利用者に情報の記憶、操作又は転記を要求するタスク。">認知機能のテスト</a> (パスワードを記憶する、パズルを解くなど) は、認証<a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-3" title="一連の利用者の動作で、それぞれの動作はある活動を完了させるために必須であるもの。">プロセス</a>のどのステップにおいても要求されない。ただし、そのステップが次の少なくとも一つを提供する場合は除く:</p> 
+    <p><a href="#dfn-cognitive-function-test" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-cognitive-function-test-1" title="利用者に情報の記憶、操作又は転記を要求するタスク。">認知機能のテスト</a> (パスワードを記憶する、パズルを解くなど) は、認証<a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-3" title="一連の利用者の動作で、それぞれの動作はあるアクティビティを完了させるために必須であるもの。">プロセス</a>のどのステップにおいても要求されない。ただし、そのステップが次の少なくとも一つを提供する場合は除く:</p> 
     <dl>
         <dt>代替</dt>
         <dd>認知機能のテストに依存しない別の認証方法がある。</dd>
@@ -1962,7 +1962,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
     <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-enhanced.html">Understanding Accessible Authentication (Enhanced)</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG22/quickref/#accessible-authentication-enhanced">How to Meet Accessible Authentication (Enhanced)</a></div><p class="conformance-level">(レベル AAA)</p>
 	<p class="change">New</p>
     
-    <p><a href="#dfn-cognitive-function-test" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-cognitive-function-test-2" title="利用者に情報の記憶、操作又は転記を要求するタスク。">認知機能のテスト</a> (パスワードを記憶する、パズルを解くなど) は、認証<a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-4" title="一連の利用者の動作で、それぞれの動作はある活動を完了させるために必須であるもの。">プロセス</a>のどのステップにおいても要求されない。ただし、そのステップが次の少なくとも一つを提供する場合は除く:</p> 
+    <p><a href="#dfn-cognitive-function-test" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-cognitive-function-test-2" title="利用者に情報の記憶、操作又は転記を要求するタスク。">認知機能のテスト</a> (パスワードを記憶する、パズルを解くなど) は、認証<a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-4" title="一連の利用者の動作で、それぞれの動作はあるアクティビティを完了させるために必須であるもの。">プロセス</a>のどのステップにおいても要求されない。ただし、そのステップが次の少なくとも一つを提供する場合は除く:</p> 
     <dl>
         <dt>代替</dt>
         <dd>認知機能のテストに依存しない別の認証方法がある。</dd>
@@ -2063,7 +2063,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
             	
             	<section id="cc3"><div class="header-wrapper"><h4 id="x5-2-3-complete-processes"><bdi class="secno">5.2.3 </bdi>プロセス全体</h4><a class="self-link" href="#cc3" aria-label="Permalink for Section 5.2.3"></a></div>
                     
-                    <p>ある<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-14" title="HTTP を使用して単一の URI から取得された埋め込まれていないリソースに加え、レンダリングに使われる、又はユーザエージェントがこのリソースと一緒にレンダリングすることを意図しているあらゆるその他のリソースを合わせたもの。">ウェブページ</a>が、ある<a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-5" title="一連の利用者の動作で、それぞれの動作はある活動を完了させるために必須であるもの。">プロセス</a> (つまり、ある活動を達成するために完了する必要がある一連の手順) を示す一連のウェブページのうちの一つである場合、そのプロセスに含まれる全てのウェブページが指定されたレベル以上で適合している。(プロセスに含まれるいずれかのページが特定のレベル以上で適合していない場合、そのレベルでの適合は不可能である。)</p>
+                    <p>ある<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-14" title="HTTP を使用して単一の URI から取得された埋め込まれていないリソースに加え、レンダリングに使われる、又はユーザエージェントがこのリソースと一緒にレンダリングすることを意図しているあらゆるその他のリソースを合わせたもの。">ウェブページ</a>が、ある<a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-5" title="一連の利用者の動作で、それぞれの動作はあるアクティビティを完了させるために必須であるもの。">プロセス</a> (つまり、あるアクティビティを達成するために完了する必要がある一連の手順) を示す一連のウェブページのうちの一つである場合、そのプロセスに含まれる全てのウェブページが指定されたレベル以上で適合している。(プロセスに含まれるいずれかのページが特定のレベル以上で適合していない場合、そのレベルでの適合は不可能である。)</p>
                     <aside class="example" id="example-1"><div class="marker">例</div><p>あるオンラインストアには、製品を選択して購入するために使用される一連のページがある。プロセスに含まれるあるページが適合するために、最初から最後 (支払い) まで一連の全てのページが適合している。</p></aside>
                 </section>
 
@@ -2764,7 +2764,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
             	<dt><dfn id="dfn-functionality" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">機能 (functionality)</dfn></dt>
 <dd>
    
-   <p>利用者の操作によって実現可能な<a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-6" title="一連の利用者の動作で、それぞれの動作はある活動を完了させるために必須であるもの。">プロセス</a>及び結果。
+   <p>利用者の操作によって実現可能な<a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-6" title="一連の利用者の動作で、それぞれの動作はあるアクティビティを完了させるために必須であるもの。">プロセス</a>及び結果。
    </p>
    
 </dd>
@@ -3013,7 +3013,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
                 <dt><dfn id="dfn-mechanism" data-lt="mechanisms|mechanism" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">メカニズム (mechanism)</dfn></dt>
 <dd>
    
-   <p>結果を得るための<a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-7" title="一連の利用者の動作で、それぞれの動作はある活動を完了させるために必須であるもの。">プロセス</a>又は手法。
+   <p>結果を得るための<a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-7" title="一連の利用者の動作で、それぞれの動作はあるアクティビティを完了させるために必須であるもの。">プロセス</a>又は手法。
    </p>
    
    <div class="note" role="note" id="issue-container-generatedID-122"><div role="heading" class="note-title marker" id="h-note-122" aria-level="3"><span>注記 1</span></div><p class="">メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-assistive-technologies-7" title="障害のある利用者の要件を満たすために、主流のユーザエージェントが提供する機能を超えた機能を提供するような、ユーザエージェントとして動作する、又は主流のユーザエージェントと共に動作するハードウェア及び／又はソフトウェア。">支援技術</a>を含む<a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-agents-12" title="ウェブコンテンツを取得して利用者に提示するあらゆるソフトウェア。">ユーザエージェント</a>で提供されるものに<a href="#dfn-relied-upon" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-relied-upon-8" title="その技術が無効になっている場合、又はサポートされていない場合に、コンテンツが適合できないこと。">依存</a>することもある。
@@ -3167,7 +3167,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
                 <dt><dfn id="dfn-processes" data-lt="processes|process" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">プロセス (process)</dfn></dt>
 <dd>
    
-   <p>一連の利用者の動作で、それぞれの動作はある活動を完了させるために必須であるもの。</p>
+   <p>一連の利用者の動作で、それぞれの動作はあるアクティビティを完了させるために必須であるもの。</p>
    
    <aside class="example" id="example-17"><div class="marker">例 1</div><p>ショッピングサイト上の一連のウェブページで目的を果たすためには、利用者が選択肢となり得る製品、価格及び契約条件を閲覧した後、製品を選択して発注し、配送先情報及び支払情報を提供する必要がある。
    </p></aside>
@@ -3452,7 +3452,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
                 <dt><dfn id="dfn-status-messages" data-lt="status messages|status message" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">ステータスメッセージ (status message)</dfn></dt>
 <dd>
    					
-   <p>コンテンツ内の変化であって、<a href="#dfn-change-of-context" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-change-of-context-4" title="大きな変化で、利用者が気づかないと、ウェブページ全体を一度に見ることのできない利用者を混乱させる恐れのあるもの。">コンテキストの変化</a>ではなく、かつ、アクションの成功もしくは結果、アプリケーションの処理待ち状態、<a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-8" title="一連の利用者の動作で、それぞれの動作はある活動を完了させるために必須であるもの。">プロセス</a>の進捗、又はエラーの存在に関する情報を利用者に提供するもの。</p>
+   <p>コンテンツ内の変化であって、<a href="#dfn-change-of-context" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-change-of-context-4" title="大きな変化で、利用者が気づかないと、ウェブページ全体を一度に見ることのできない利用者を混乱させる恐れのあるもの。">コンテキストの変化</a>ではなく、かつ、アクションの成功もしくは結果、アプリケーションの処理待ち状態、<a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-8" title="一連の利用者の動作で、それぞれの動作はあるアクティビティを完了させるために必須であるもの。">プロセス</a>の進捗、又はエラーの存在に関する情報を利用者に提供するもの。</p>
    
 </dd>
 
@@ -3494,7 +3494,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
    <aside class="example" id="example-30"><div class="marker">例 1</div><p><a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-22" title="HTTP を使用して単一の URI から取得された埋め込まれていないリソースに加え、レンダリングに使われる、又はユーザエージェントがこのリソースと一緒にレンダリングすることを意図しているあらゆるその他のリソースを合わせたもの。">ウェブページ</a>の音声版。</a>
    </p></aside>
    
-   <aside class="example" id="example-31"><div class="marker">例 2</div><p>複雑な<a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-9" title="一連の利用者の動作で、それぞれの動作はある活動を完了させるために必須であるもの。">プロセス</a>の図解。
+   <aside class="example" id="example-31"><div class="marker">例 2</div><p>複雑な<a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-9" title="一連の利用者の動作で、それぞれの動作はあるアクティビティを完了させるために必須であるもの。">プロセス</a>の図解。
    </p></aside>
    
    <aside class="example" id="example-32"><div class="marker">例 3</div><p>調査研究で得られた主要な成果及び提言を要約する段落。


### PR DESCRIPTION
close #1686 

2026-05-14 の WG6-SG1 での結論にもとづき、一部、「活動」と訳されている箇所を「アクティビティ」としました。