### PR TITLE
用語「映像 (video)」注記内「は」が抜けている問題の修正

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -3640,7 +3640,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
    
    <p>写真もしくは画像を動かす、又はシーケンス化する技術。</p>
    
-   <div class="note" role="note" id="issue-container-generatedID-155"><div role="heading" class="note-title marker" id="h-note-155" aria-level="3"><span>注記</span></div><p class="">映像は、アニメーション画像もしく実写画像、又はその両方で構成され得る。</p></div>
+   <div class="note" role="note" id="issue-container-generatedID-155"><div role="heading" class="note-title marker" id="h-note-155" aria-level="3"><span>注記</span></div><p class="">映像は、アニメーション画像もしくは実写画像、又はその両方で構成され得る。</p></div>
    
 </dd>
 

--- a/understanding/audio-description-or-media-alternative-prerecorded.html
+++ b/understanding/audio-description-or-media-alternative-prerecorded.html
@@ -555,7 +555,7 @@
                         
                         <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                            <p class="note-title marker">注記</p>
-                           <p>映像は、アニメーション画像もしく実写画像、又はその両方で構成され得る。</p>
+                           <p>映像は、アニメーション画像もしくは実写画像、又はその両方で構成され得る。</p>
                         </div>
                         
                         

--- a/understanding/audio-description-prerecorded.html
+++ b/understanding/audio-description-prerecorded.html
@@ -482,7 +482,7 @@
                         
                         <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                            <p class="note-title marker">注記</p>
-                           <p>映像は、アニメーション画像もしく実写画像、又はその両方で構成され得る。</p>
+                           <p>映像は、アニメーション画像もしくは実写画像、又はその両方で構成され得る。</p>
                         </div>
                         
                         

--- a/understanding/audio-only-and-video-only-prerecorded.html
+++ b/understanding/audio-only-and-video-only-prerecorded.html
@@ -465,7 +465,7 @@
                         
                         <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                            <p class="note-title marker">注記</p>
-                           <p>映像は、アニメーション画像もしく実写画像、又はその両方で構成され得る。</p>
+                           <p>映像は、アニメーション画像もしくは実写画像、又はその両方で構成され得る。</p>
                         </div>
                         
                         

--- a/understanding/audio-only-live.html
+++ b/understanding/audio-only-live.html
@@ -280,7 +280,7 @@
                         
                         <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                            <p class="note-title marker">注記</p>
-                           <p>映像は、アニメーション画像もしく実写画像、又はその両方で構成され得る。</p>
+                           <p>映像は、アニメーション画像もしくは実写画像、又はその両方で構成され得る。</p>
                         </div>
                         
                         

--- a/understanding/captions-live.html
+++ b/understanding/captions-live.html
@@ -679,7 +679,7 @@
                         
                         <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                            <p class="note-title marker">注記</p>
-                           <p>映像は、アニメーション画像もしく実写画像、又はその両方で構成され得る。</p>
+                           <p>映像は、アニメーション画像もしくは実写画像、又はその両方で構成され得る。</p>
                         </div>
                         
                         

--- a/understanding/captions-prerecorded.html
+++ b/understanding/captions-prerecorded.html
@@ -822,7 +822,7 @@
                         
                         <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                            <p class="note-title marker">注記</p>
-                           <p>映像は、アニメーション画像もしく実写画像、又はその両方で構成され得る。</p>
+                           <p>映像は、アニメーション画像もしくは実写画像、又はその両方で構成され得る。</p>
                         </div>
                         
                         

--- a/understanding/extended-audio-description-prerecorded.html
+++ b/understanding/extended-audio-description-prerecorded.html
@@ -398,7 +398,7 @@
                         
                         <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                            <p class="note-title marker">注記</p>
-                           <p>映像は、アニメーション画像もしく実写画像、又はその両方で構成され得る。</p>
+                           <p>映像は、アニメーション画像もしくは実写画像、又はその両方で構成され得る。</p>
                         </div>
                         
                         

--- a/understanding/low-or-no-background-audio.html
+++ b/understanding/low-or-no-background-audio.html
@@ -318,7 +318,7 @@
                         
                         <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                            <p class="note-title marker">注記</p>
-                           <p>映像は、アニメーション画像もしく実写画像、又はその両方で構成され得る。</p>
+                           <p>映像は、アニメーション画像もしくは実写画像、又はその両方で構成され得る。</p>
                         </div>
                         
                         

--- a/understanding/media-alternative-prerecorded.html
+++ b/understanding/media-alternative-prerecorded.html
@@ -774,7 +774,7 @@
                         
                         <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                            <p class="note-title marker">注記</p>
-                           <p>映像は、アニメーション画像もしく実写画像、又はその両方で構成され得る。</p>
+                           <p>映像は、アニメーション画像もしくは実写画像、又はその両方で構成され得る。</p>
                         </div>
                         
                         

--- a/understanding/no-timing.html
+++ b/understanding/no-timing.html
@@ -280,7 +280,7 @@
                         
                         <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                            <p class="note-title marker">注記</p>
-                           <p>映像は、アニメーション画像もしく実写画像、又はその両方で構成され得る。</p>
+                           <p>映像は、アニメーション画像もしくは実写画像、又はその両方で構成され得る。</p>
                         </div>
                         
                         

--- a/understanding/resize-text.html
+++ b/understanding/resize-text.html
@@ -837,7 +837,7 @@
                         
                         <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                            <p class="note-title marker">注記</p>
-                           <p>映像は、アニメーション画像もしく実写画像、又はその両方で構成され得る。</p>
+                           <p>映像は、アニメーション画像もしくは実写画像、又はその両方で構成され得る。</p>
                         </div>
                         
                         

--- a/understanding/sign-language-prerecorded.html
+++ b/understanding/sign-language-prerecorded.html
@@ -375,7 +375,7 @@
                         
                         <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                            <p class="note-title marker">注記</p>
-                           <p>映像は、アニメーション画像もしく実写画像、又はその両方で構成され得る。</p>
+                           <p>映像は、アニメーション画像もしくは実写画像、又はその両方で構成され得る。</p>
                         </div>
                         
                         


### PR DESCRIPTION
用語「映像 (video)」注記内にて、「は」が抜けている問題の修正を行いました。

変更前
> 映像は、アニメーション画像もしく実写画像、又はその両方で構成され得る。

変更後
> 映像は、アニメーション画像もしくは実写画像、又はその両方で構成され得る。