### PR TITLE
SLシリーズ（廃止）の翻訳

### DIFF
--- a/techniques/silverlight/SL1.html
+++ b/techniques/silverlight/SL1.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL1: Accessing Alternate Audio Tracks in Silverlight Media | WAI | W3C</title>
+<title>[廃止] SL1: Accessing Alternate Audio Tracks in Silverlight Media | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL1.html
+++ b/techniques/silverlight/SL1.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL10.html
+++ b/techniques/silverlight/SL10.html
@@ -70,7 +70,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL10.html
+++ b/techniques/silverlight/SL10.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL10: Implementing a Submit-Form Pattern in Silverlight | WAI | W3C</title>
+<title>[廃止] SL10: Implementing a Submit-Form Pattern in Silverlight | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL11.html
+++ b/techniques/silverlight/SL11.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL11.html
+++ b/techniques/silverlight/SL11.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL11: Pausing or Stopping A Decorative Silverlight Animation | WAI | W3C</title>
+<title>[廃止] SL11: Pausing or Stopping A Decorative Silverlight Animation | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL12.html
+++ b/techniques/silverlight/SL12.html
@@ -70,7 +70,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL12.html
+++ b/techniques/silverlight/SL12.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL12: Pausing, Stopping, or Playing Media in Silverlight MediaElements | WAI | W3C</title>
+<title>[廃止] SL12: Pausing, Stopping, or Playing Media in Silverlight MediaElements | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL13.html
+++ b/techniques/silverlight/SL13.html
@@ -70,7 +70,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL13.html
+++ b/techniques/silverlight/SL13.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL13: Providing A Style Switcher To Switch To High Contrast | WAI | W3C</title>
+<title>[廃止] SL13: Providing A Style Switcher To Switch To High Contrast | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL14.html
+++ b/techniques/silverlight/SL14.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL14: Providing Custom Control Key Handling for Keyboard Functionality
+<title>[廃止] SL14: Providing Custom Control Key Handling for Keyboard Functionality
     			in Silverlight | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -71,8 +71,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL14.html
+++ b/techniques/silverlight/SL14.html
@@ -72,7 +72,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL15.html
+++ b/techniques/silverlight/SL15.html
@@ -72,7 +72,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL15.html
+++ b/techniques/silverlight/SL15.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL15: Providing Keyboard Shortcuts that Work Across the Entire Silverlight
+<title>[廃止] SL15: Providing Keyboard Shortcuts that Work Across the Entire Silverlight
     			Application | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -71,8 +71,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL16.html
+++ b/techniques/silverlight/SL16.html
@@ -70,7 +70,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL16.html
+++ b/techniques/silverlight/SL16.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL16: Providing Script-Embedded Text Captions for MediaElement Content | WAI | W3C</title>
+<title>[廃止] SL16: Providing Script-Embedded Text Captions for MediaElement Content | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL17.html
+++ b/techniques/silverlight/SL17.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL17: Providing Static Alternative Content for Silverlight Media Playing
+<title>[廃止] SL17: Providing Static Alternative Content for Silverlight Media Playing
     			in a MediaElement | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -70,8 +70,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL17.html
+++ b/techniques/silverlight/SL17.html
@@ -71,7 +71,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL18.html
+++ b/techniques/silverlight/SL18.html
@@ -70,7 +70,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL18.html
+++ b/techniques/silverlight/SL18.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL18: Providing Text Equivalent for Nontext Silverlight Controls With AutomationProperties.Name | WAI | W3C</title>
+<title>[廃止] SL18: Providing Text Equivalent for Nontext Silverlight Controls With AutomationProperties.Name | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL19.html
+++ b/techniques/silverlight/SL19.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL19: Providing User Instructions With AutomationProperties.HelpText in
+<title>[廃止] SL19: Providing User Instructions With AutomationProperties.HelpText in
     			Silverlight | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -71,8 +71,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL19.html
+++ b/techniques/silverlight/SL19.html
@@ -72,7 +72,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL2.html
+++ b/techniques/silverlight/SL2.html
@@ -70,7 +70,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL2.html
+++ b/techniques/silverlight/SL2.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL2: Changing The Visual Focus Indicator in Silverlight | WAI | W3C</title>
+<title>[廃止] SL2: Changing The Visual Focus Indicator in Silverlight | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL20.html
+++ b/techniques/silverlight/SL20.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL20: Relying on Silverlight AutomationPeer Behavior to Set AutomationProperties.Name | WAI | W3C</title>
+<title>[廃止] SL20: Relying on Silverlight AutomationPeer Behavior to Set AutomationProperties.Name | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL20.html
+++ b/techniques/silverlight/SL20.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL21.html
+++ b/techniques/silverlight/SL21.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL21.html
+++ b/techniques/silverlight/SL21.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL21: Replacing A Silverlight Timed Animation With a Nonanimated Element | WAI | W3C</title>
+<title>[廃止] SL21: Replacing A Silverlight Timed Animation With a Nonanimated Element | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL22.html
+++ b/techniques/silverlight/SL22.html
@@ -70,7 +70,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL22.html
+++ b/techniques/silverlight/SL22.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL22: Supporting Browser Zoom in Silverlight | WAI | W3C</title>
+<title>[廃止] SL22: Supporting Browser Zoom in Silverlight | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL23.html
+++ b/techniques/silverlight/SL23.html
@@ -72,7 +72,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL23.html
+++ b/techniques/silverlight/SL23.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL23: Using A Style Switcher to Increase Font Size of Silverlight Text
+<title>[廃止] SL23: Using A Style Switcher to Increase Font Size of Silverlight Text
     			Elements | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -71,8 +71,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL24.html
+++ b/techniques/silverlight/SL24.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL24: Using AutoPlay to Keep Silverlight Media from Playing Automatically | WAI | W3C</title>
+<title>[廃止] SL24: Using AutoPlay to Keep Silverlight Media from Playing Automatically | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL24.html
+++ b/techniques/silverlight/SL24.html
@@ -70,7 +70,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL25.html
+++ b/techniques/silverlight/SL25.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL25: Using Controls and Programmatic Focus to Bypass Blocks of Content
+<title>[廃止] SL25: Using Controls and Programmatic Focus to Bypass Blocks of Content
     			in Silverlight | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -71,8 +71,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL25.html
+++ b/techniques/silverlight/SL25.html
@@ -72,7 +72,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL26.html
+++ b/techniques/silverlight/SL26.html
@@ -70,7 +70,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL26.html
+++ b/techniques/silverlight/SL26.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL26: Using LabeledBy to Associate Labels and Targets in Silverlight | WAI | W3C</title>
+<title>[廃止] SL26: Using LabeledBy to Associate Labels and Targets in Silverlight | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL27.html
+++ b/techniques/silverlight/SL27.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL27: Using Language/Culture Properties as Exposed by Silverlight Applications
+<title>[廃止] SL27: Using Language/Culture Properties as Exposed by Silverlight Applications
     			and Assistive Technologies | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -70,8 +70,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL27.html
+++ b/techniques/silverlight/SL27.html
@@ -71,7 +71,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL28.html
+++ b/techniques/silverlight/SL28.html
@@ -70,7 +70,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL28.html
+++ b/techniques/silverlight/SL28.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL28: Using Separate Text-Format Text Captions for MediaElement Content | WAI | W3C</title>
+<title>[廃止] SL28: Using Separate Text-Format Text Captions for MediaElement Content | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL29.html
+++ b/techniques/silverlight/SL29.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL29: Using Silverlight "List" Controls to Define Blocks that
+<title>[廃止] SL29: Using Silverlight "List" Controls to Define Blocks that
     			can be Bypassed | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -71,8 +71,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL29.html
+++ b/techniques/silverlight/SL29.html
@@ -72,7 +72,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL3.html
+++ b/techniques/silverlight/SL3.html
@@ -70,7 +70,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL3.html
+++ b/techniques/silverlight/SL3.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL3: Controlling Silverlight MediaElement Audio Volume | WAI | W3C</title>
+<title>[廃止] SL3: Controlling Silverlight MediaElement Audio Volume | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL30.html
+++ b/techniques/silverlight/SL30.html
@@ -70,7 +70,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL30.html
+++ b/techniques/silverlight/SL30.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL30: Using Silverlight Control Compositing and AutomationProperties.Name | WAI | W3C</title>
+<title>[廃止] SL30: Using Silverlight Control Compositing and AutomationProperties.Name | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL31.html
+++ b/techniques/silverlight/SL31.html
@@ -70,7 +70,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL31.html
+++ b/techniques/silverlight/SL31.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL31: Using Silverlight Font Properties to Control Text Presentation | WAI | W3C</title>
+<title>[廃止] SL31: Using Silverlight Font Properties to Control Text Presentation | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL32.html
+++ b/techniques/silverlight/SL32.html
@@ -70,7 +70,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL32.html
+++ b/techniques/silverlight/SL32.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL32: Using Silverlight Text Elements for Appropriate Accessibility Role | WAI | W3C</title>
+<title>[廃止] SL32: Using Silverlight Text Elements for Appropriate Accessibility Role | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL33.html
+++ b/techniques/silverlight/SL33.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL33: Using Well-Formed XAML to Define a Silverlight User Interface | WAI | W3C</title>
+<title>[廃止] SL33: Using Well-Formed XAML to Define a Silverlight User Interface | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL33.html
+++ b/techniques/silverlight/SL33.html
@@ -70,7 +70,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL34.html
+++ b/techniques/silverlight/SL34.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL34: Using the Silverlight Default Tab Sequence and Altering Tab Sequences
+<title>[廃止] SL34: Using the Silverlight Default Tab Sequence and Altering Tab Sequences
     			With Properties | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -70,8 +70,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL34.html
+++ b/techniques/silverlight/SL34.html
@@ -71,7 +71,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL35.html
+++ b/techniques/silverlight/SL35.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL35: Using the Validation and ValidationSummary APIs to Implement Client
+<title>[廃止] SL35: Using the Validation and ValidationSummary APIs to Implement Client
     			Side Forms Validation in Silverlight | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -71,8 +71,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL35.html
+++ b/techniques/silverlight/SL35.html
@@ -72,7 +72,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL4.html
+++ b/techniques/silverlight/SL4.html
@@ -72,7 +72,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL4.html
+++ b/techniques/silverlight/SL4.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL4: Declaring Discrete Silverlight Objects to Specify Language Parts
+<title>[廃止] SL4: Declaring Discrete Silverlight Objects to Specify Language Parts
     			in the HTML DOM | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -71,8 +71,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL5.html
+++ b/techniques/silverlight/SL5.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL5: Defining a Focusable Image Class for Silverlight | WAI | W3C</title>
+<title>[廃止] SL5: Defining a Focusable Image Class for Silverlight | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL5.html
+++ b/techniques/silverlight/SL5.html
@@ -70,7 +70,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL6.html
+++ b/techniques/silverlight/SL6.html
@@ -70,7 +70,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL6.html
+++ b/techniques/silverlight/SL6.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL6: Defining a UI Automation Peer for a Custom Silverlight Control | WAI | W3C</title>
+<title>[廃止] SL6: Defining a UI Automation Peer for a Custom Silverlight Control | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL7.html
+++ b/techniques/silverlight/SL7.html
@@ -70,7 +70,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL7.html
+++ b/techniques/silverlight/SL7.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL7: Designing a Focused Visual State for Custom Silverlight Controls | WAI | W3C</title>
+<title>[廃止] SL7: Designing a Focused Visual State for Custom Silverlight Controls | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL8.html
+++ b/techniques/silverlight/SL8.html
@@ -70,7 +70,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL8.html
+++ b/techniques/silverlight/SL8.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL8: Displaying HelpText in Silverlight User Interfaces | WAI | W3C</title>
+<title>[廃止] SL8: Displaying HelpText in Silverlight User Interfaces | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/silverlight/SL9.html
+++ b/techniques/silverlight/SL9.html
@@ -70,7 +70,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft は 2021 年に Silverlight のサポートを終了した</a>。コンテンツ制作者はアクセシブルなウェブコンテンツには HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/silverlight/SL9.html
+++ b/techniques/silverlight/SL9.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SL9: Handling Key Events to Enable Keyboard Functionality in Silverlight | WAI | W3C</title>
+<title>[廃止] SL9: Handling Key Events to Enable Keyboard Functionality in Silverlight | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoft ended support for Silverlight</a> in 2021, and authors are encouraged to use HTML for accessible web content.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://learn.microsoft.com/en-us/lifecycle/announcements/silverlight-end-of-support">Microsoftは2021年にSilverlightのサポートを終了しました</a>。コンテンツ制作者はアクセシブルなウェブコンテンツにはHTMLの使用が推奨されています。</div>
 </section>
 
 


### PR DESCRIPTION
close #950 #951 #952 #953 #954 #955 #956 #957 #958 #959 #960 #961 #962 #963 #964 #965 #966 #967 #968 #969 #970 #971 #972 #973 #974 #975 #976 #977 #978 #979 #980 #981 #982 #983 #984 

テクニック集 SL1からSL35まで、すべて廃止済みであるため、`<title>` 冒頭と廃止済みであることを伝えるメッセージのみ日本語に翻訳しました。
#1074 を参考にしました。



