### PR TITLE
FLASHシリーズ（廃止）の翻訳

### DIFF
--- a/techniques/flash/FLASH1.html
+++ b/techniques/flash/FLASH1.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH1.html
+++ b/techniques/flash/FLASH1.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH1: Setting the name property for a non-text object | WAI | W3C</title>
+<title>[廃止] FLASH1: Setting the name property for a non-text object | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH10.html
+++ b/techniques/flash/FLASH10.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH10: Indicating required form controls in Flash | WAI | W3C</title>
+<title>[廃止] FLASH10: Indicating required form controls in Flash | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -67,8 +67,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH10.html
+++ b/techniques/flash/FLASH10.html
@@ -68,7 +68,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH11.html
+++ b/techniques/flash/FLASH11.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH11.html
+++ b/techniques/flash/FLASH11.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH11: Providing a longer text description of an object | WAI | W3C</title>
+<title>[廃止] FLASH11: Providing a longer text description of an object | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH12.html
+++ b/techniques/flash/FLASH12.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH12.html
+++ b/techniques/flash/FLASH12.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH12: Providing client-side validation and adding error text via the accessible description | WAI | W3C</title>
+<title>[廃止] FLASH12: Providing client-side validation and adding error text via the accessible description | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH13.html
+++ b/techniques/flash/FLASH13.html
@@ -70,7 +70,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH13.html
+++ b/techniques/flash/FLASH13.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH13: Using HTML language attributes to specify language in Flash content | WAI | W3C</title>
+<title>[廃止] FLASH13: Using HTML language attributes to specify language in Flash content | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH14.html
+++ b/techniques/flash/FLASH14.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH14.html
+++ b/techniques/flash/FLASH14.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH14: Using redundant keyboard and mouse event handlers in Flash | WAI | W3C</title>
+<title>[廃止] FLASH14: Using redundant keyboard and mouse event handlers in Flash | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH15.html
+++ b/techniques/flash/FLASH15.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH15: Using the tabIndex property to specify a logical reading order and a logical tab order in Flash | WAI | W3C</title>
+<title>[廃止] FLASH15: Using the tabIndex property to specify a logical reading order and a logical tab order in Flash | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH15.html
+++ b/techniques/flash/FLASH15.html
@@ -70,7 +70,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH16.html
+++ b/techniques/flash/FLASH16.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH16.html
+++ b/techniques/flash/FLASH16.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH16: Making actions keyboard accessible by using the click event on standard components | WAI | W3C</title>
+<title>[廃止] FLASH16: Making actions keyboard accessible by using the click event on standard components | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH17.html
+++ b/techniques/flash/FLASH17.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH17.html
+++ b/techniques/flash/FLASH17.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH17: Providing keyboard access to a Flash object and avoiding a keyboard trap | WAI | W3C</title>
+<title>[廃止] FLASH17: Providing keyboard access to a Flash object and avoiding a keyboard trap | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH18.html
+++ b/techniques/flash/FLASH18.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH18.html
+++ b/techniques/flash/FLASH18.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH18: Providing a control to turn off sounds that play automatically in Flash | WAI | W3C</title>
+<title>[廃止] FLASH18: Providing a control to turn off sounds that play automatically in Flash | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH19.html
+++ b/techniques/flash/FLASH19.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH19.html
+++ b/techniques/flash/FLASH19.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH19: Providing a script that warns the user a time limit is about to expire and provides a way to extend it | WAI | W3C</title>
+<title>[廃止] FLASH19: Providing a script that warns the user a time limit is about to expire and provides a way to extend it | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH2.html
+++ b/techniques/flash/FLASH2.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH2: Setting the description property for a non-text object in Flash | WAI | W3C</title>
+<title>[廃止] FLASH2: Setting the description property for a non-text object in Flash | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH2.html
+++ b/techniques/flash/FLASH2.html
@@ -70,7 +70,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH20.html
+++ b/techniques/flash/FLASH20.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH20: Reskinning Flash components to provide highly visible focus indication | WAI | W3C</title>
+<title>[廃止] FLASH20: Reskinning Flash components to provide highly visible focus indication | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH20.html
+++ b/techniques/flash/FLASH20.html
@@ -70,7 +70,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH21.html
+++ b/techniques/flash/FLASH21.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH21: Using the DataGrid component to associate column headers with cells | WAI | W3C</title>
+<title>[廃止] FLASH21: Using the DataGrid component to associate column headers with cells | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -67,8 +67,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH21.html
+++ b/techniques/flash/FLASH21.html
@@ -68,7 +68,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH22.html
+++ b/techniques/flash/FLASH22.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH22.html
+++ b/techniques/flash/FLASH22.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH22: Adding keyboard-accessible actions to static elements | WAI | W3C</title>
+<title>[廃止] FLASH22: Adding keyboard-accessible actions to static elements | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH23.html
+++ b/techniques/flash/FLASH23.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH23: Adding summary information to a DataGrid | WAI | W3C</title>
+<title>[廃止] FLASH23: Adding summary information to a DataGrid | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -67,8 +67,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH23.html
+++ b/techniques/flash/FLASH23.html
@@ -68,7 +68,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH24.html
+++ b/techniques/flash/FLASH24.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH24.html
+++ b/techniques/flash/FLASH24.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH24: Allowing the user to extend the default time limit | WAI | W3C</title>
+<title>[廃止] FLASH24: Allowing the user to extend the default time limit | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH25.html
+++ b/techniques/flash/FLASH25.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH25.html
+++ b/techniques/flash/FLASH25.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH25: Labeling a form control by setting its accessible name | WAI | W3C</title>
+<title>[廃止] FLASH25: Labeling a form control by setting its accessible name | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH26.html
+++ b/techniques/flash/FLASH26.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH26.html
+++ b/techniques/flash/FLASH26.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH26: Applying audio descriptions to Flash video | WAI | W3C</title>
+<title>[廃止] FLASH26: Applying audio descriptions to Flash video | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH27.html
+++ b/techniques/flash/FLASH27.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH27.html
+++ b/techniques/flash/FLASH27.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH27: Providing button labels that describe the purpose of a button | WAI | W3C</title>
+<title>[廃止] FLASH27: Providing button labels that describe the purpose of a button | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH28.html
+++ b/techniques/flash/FLASH28.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH28: Providing text alternatives for ASCII art, emoticons, and leetspeak in Flash | WAI | W3C</title>
+<title>[廃止] FLASH28: Providing text alternatives for ASCII art, emoticons, and leetspeak in Flash | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -67,8 +67,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH28.html
+++ b/techniques/flash/FLASH28.html
@@ -68,7 +68,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH29.html
+++ b/techniques/flash/FLASH29.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH29.html
+++ b/techniques/flash/FLASH29.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH29: Setting the label property for form components | WAI | W3C</title>
+<title>[廃止] FLASH29: Setting the label property for form components | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH3.html
+++ b/techniques/flash/FLASH3.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH3: Marking objects in Flash so that they can be ignored by AT | WAI | W3C</title>
+<title>[廃止] FLASH3: Marking objects in Flash so that they can be ignored by AT | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH3.html
+++ b/techniques/flash/FLASH3.html
@@ -70,7 +70,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH30.html
+++ b/techniques/flash/FLASH30.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH30.html
+++ b/techniques/flash/FLASH30.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH30: Specifying accessible names for image buttons | WAI | W3C</title>
+<title>[廃止] FLASH30: Specifying accessible names for image buttons | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH31.html
+++ b/techniques/flash/FLASH31.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH31: Specifying caption text for a DataGrid | WAI | W3C</title>
+<title>[廃止] FLASH31: Specifying caption text for a DataGrid | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH31.html
+++ b/techniques/flash/FLASH31.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH32.html
+++ b/techniques/flash/FLASH32.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH32.html
+++ b/techniques/flash/FLASH32.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH32: Using auto labeling to associate text labels with form controls | WAI | W3C</title>
+<title>[廃止] FLASH32: Using auto labeling to associate text labels with form controls | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH33.html
+++ b/techniques/flash/FLASH33.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH33.html
+++ b/techniques/flash/FLASH33.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH33: Using relative values for Flash object dimensions | WAI | W3C</title>
+<title>[廃止] FLASH33: Using relative values for Flash object dimensions | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH34.html
+++ b/techniques/flash/FLASH34.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH34: Turning off sounds that play automatically when an assistive technology is detected | WAI | W3C</title>
+<title>[廃止] FLASH34: Turning off sounds that play automatically when an assistive technology is detected | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH34.html
+++ b/techniques/flash/FLASH34.html
@@ -70,7 +70,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH35.html
+++ b/techniques/flash/FLASH35.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH35.html
+++ b/techniques/flash/FLASH35.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH35: Using script to scroll Flash content, and providing a mechanism to pause it | WAI | W3C</title>
+<title>[廃止] FLASH35: Using script to scroll Flash content, and providing a mechanism to pause it | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH36.html
+++ b/techniques/flash/FLASH36.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH36: Using scripts to control blinking and stop it in five seconds or less | WAI | W3C</title>
+<title>[廃止] FLASH36: Using scripts to control blinking and stop it in five seconds or less | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -67,8 +67,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH36.html
+++ b/techniques/flash/FLASH36.html
@@ -68,7 +68,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH4.html
+++ b/techniques/flash/FLASH4.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH4.html
+++ b/techniques/flash/FLASH4.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH4: Providing submit buttons in Flash | WAI | W3C</title>
+<title>[廃止] FLASH4: Providing submit buttons in Flash | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH5.html
+++ b/techniques/flash/FLASH5.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH5.html
+++ b/techniques/flash/FLASH5.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH5: Combining adjacent image and text buttons for the same resource | WAI | W3C</title>
+<title>[廃止] FLASH5: Combining adjacent image and text buttons for the same resource | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH6.html
+++ b/techniques/flash/FLASH6.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH6.html
+++ b/techniques/flash/FLASH6.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH6: Creating accessible hotspots using invisible buttons | WAI | W3C</title>
+<title>[廃止] FLASH6: Creating accessible hotspots using invisible buttons | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH7.html
+++ b/techniques/flash/FLASH7.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH7.html
+++ b/techniques/flash/FLASH7.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH7: Using scripting to change control labels | WAI | W3C</title>
+<title>[廃止] FLASH7: Using scripting to change control labels | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH8.html
+++ b/techniques/flash/FLASH8.html
@@ -69,7 +69,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 

--- a/techniques/flash/FLASH8.html
+++ b/techniques/flash/FLASH8.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH8: Adding a group name to the accessible name of a form control | WAI | W3C</title>
+<title>[廃止] FLASH8: Adding a group name to the accessible name of a form control | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -68,8 +68,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH9.html
+++ b/techniques/flash/FLASH9.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] FLASH9: Applying captions to prerecorded synchronized media | WAI | W3C</title>
+<title>[廃止] FLASH9: Applying captions to prerecorded synchronized media | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe stopped updating and distributing the Flash Player</a> at the end of 2020, and encourages authors interested in creating accessible web content to use HTML.</div>
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
 </section>
 
 

--- a/techniques/flash/FLASH9.html
+++ b/techniques/flash/FLASH9.html
@@ -70,7 +70,7 @@
 
 <section class="box obsolete-message">
   <h2 class="box-h">廃止</h2>
-  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobeは2020年末にFlash Playerのアップデートと配布を終了しました</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者はHTMLの使用が推奨されています。</div>
+  <div class="box-i"><a href="https://helpx.adobe.com/enterprise/kb/eol-adobe-flash-shockwave-player.html">Adobe は 2020 年末に Flash Player のアップデートと配布を終了した</a>。アクセシブルなウェブコンテンツの制作に関心のあるコンテンツ制作者は HTML の使用が推奨されている。</div>
 </section>
 
 


### PR DESCRIPTION
close #653 #654 #655 #656 #657 #658 #659 #660 #661 #662 #663 #664 #665 #666 #667 #668 #669 #670 #671 #672 #673 #674 #675 #676 #677 #678 #679 #680 #681 #682 #683 #684 #685 #686 #677 #688

テクニック集 FLASH1からFLASH36まで、すべて廃止済みであるため、<title> 冒頭と廃止済みであることを伝えるメッセージのみ日本語に翻訳しました。
https://github.com/waic/wcag22/pull/1074 を参考にしました。