### PR TITLE
SCRシリーズ (廃止) の翻訳

### DIFF
--- a/techniques/client-side-script/SCR21.html
+++ b/techniques/client-side-script/SCR21.html
@@ -2,11 +2,9 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="" xml:lang="">
    <head>
       <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <title>SCR21: Using functions of the Document Object Model (DOM) to add content to a page | WAI | W3C</title>
+      <title>[廃止] SCR21: Using functions of the Document Object Model (DOM) to add content to a page | WAI | W3C</title>
       <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css" />
       <link rel="stylesheet" href="../base.css" />
-   <!-- 日本語訳されるまでの一時的なスクリプト -->
-<script src="../untranslated-note.js"></script>
 </head>
    <body class="wcag-docs" dir="ltr"><a href="#main" class="button button--skip-link">Skip to content</a><div class="minimal-header-container default-grid">
          <div class="minimal-header" id="site-header">
@@ -49,10 +47,13 @@
             </nav>
          </aside>
          <main id="main" class="standalone-resource__main">
-<!-- 日本語訳されるまでの一時的な注記 -->
-<div class="untranslated-note"><p>このWCAG 2.2 テクニック集の日本語訳は作業中となっています。WCAG 2.1 達成方法集の日本語訳をご利用いただけます。<br>[ <a href="https://waic.jp/translations/WCAG21/Techniques/">WCAG 2.1 達成方法集</a> ]</p></div>
             <h1><span>Technique SCR21:</span>Using functions of the Document Object Model (DOM) to add content to a page
             </h1>
+            <section class="box obsolete-message">
+              <h2 class="box-h">廃止</h2>
+              <div class="box-i">このテクニックは、アクセシビリティに何の影響も及ぼさないため、廃止されている。</div>
+            </section>
+
             <aside class="box">
                <header class="box-h  box-h-icon">
                   					About this Technique

--- a/techniques/client-side-script/SCR37.html
+++ b/techniques/client-side-script/SCR37.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta charset="UTF-8">
-<title>[Obsolete] SCR37: Creating Custom Dialogs in a Device Independent Way | WAI | W3C</title>
+<title>[廃止] SCR37: Creating Custom Dialogs in a Device Independent Way | WAI | W3C</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css">
@@ -69,8 +69,8 @@
 
 
 <section class="box obsolete-message">
-  <h2 class="box-h">Obsolete</h2>
-  <div class="box-i">See <a href="../html/H102">H102: Creating modal dialogs with the HTML dialog element</a> for a standards-based approach instead.
+  <h2 class="box-h">廃止</h2>
+  <div class="box-i">標準に準拠したアプローチとして、代わりに <a href="../html/H102">H102: Creating modal dialogs with the HTML dialog element</a> を参照のこと。
 </div>
 </section>
 


### PR DESCRIPTION
close #507 #521 

テクニック集 SCR21 および SCR 37 が廃止済みであるため、`<title>` 冒頭と廃止済みであることを伝えるメッセージのみ日本語に翻訳しました。
https://github.com/waic/wcag22/pull/1074 を参考にしました。