### PR TITLE
解説書 SC 1.1.1 共通フッターで </p> が抜けている問題を修正

### DIFF
--- a/understanding/non-text-content.html
+++ b/understanding/non-text-content.html
@@ -1621,7 +1621,7 @@
                Outreach Working Group (<a href="https://www.w3.org/groups/wg/eowg/participants">EOWG</a>) with contributions from Shadi Abou-Zahra, Steve Lee, and Shawn Lawton Henry as part
                of the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide</a> project, co-funded by the European Commission.
             </p>
-            <p>この文書は、2024 年 2 月 14 日付けの <a href="https://www.w3.org/WAI/WCAG22/Understanding/">Understanding WCAG 2.2</a> を、<a href="https://waic.jp/">ウェブアクセシビリティ基盤委員会 (WAIC)</a> の翻訳ワーキンググループが翻訳して公開しているものです。この文書の正式版は、W3C のサイトにある英語版です。正確な内容については、W3C が公開している原文 (英語) をご確認ください。この翻訳文書は作業進行中です。また、あくまで参考情報であり、翻訳上の誤りが含まれていることがあります。
+            <p>この文書は、2024 年 2 月 14 日付けの <a href="https://www.w3.org/WAI/WCAG22/Understanding/">Understanding WCAG 2.2</a> を、<a href="https://waic.jp/">ウェブアクセシビリティ基盤委員会 (WAIC)</a> の翻訳ワーキンググループが翻訳して公開しているものです。この文書の正式版は、W3C のサイトにある英語版です。正確な内容については、W3C が公開している原文 (英語) をご確認ください。この翻訳文書は作業進行中です。また、あくまで参考情報であり、翻訳上の誤りが含まれていることがあります。</p>
             <p>この翻訳文書の利用条件については、<a href="https://waic.jp/license-for-translated-documents/">WAICが提供する翻訳文書のライセンス</a>をご覧ください。</p>
          </div>
       </footer>


### PR DESCRIPTION
c.f. #2208 

解説書の共通フッターで、`</p>` (閉じタグ) が抜けている問題の修正を上記 PR で実施しましたが、一点、達成基準 1.1.1 (non-text-content.html) のみ修正ができていなかったため、追加対応しました。